### PR TITLE
feat: 회원/마이페이지 Mock API 구현 및 DTO/구조 정비

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberMockController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberMockController.java
@@ -1,0 +1,151 @@
+package com.grepp.spring.app.controller.api.member;
+
+import com.grepp.spring.app.model.member.dto.MemberLoginRequest;
+import com.grepp.spring.app.model.member.dto.MemberLoginResponse;
+import com.grepp.spring.app.model.member.dto.MemberSignupRequest;
+import com.grepp.spring.app.model.member.dto.MemberSignupResponse;
+import com.grepp.spring.app.model.member.dto.MemberLogoutRequest;
+import com.grepp.spring.app.model.member.dto.MemberLogoutResponse;
+import com.grepp.spring.app.model.member.dto.MemberEmailSendRequest;
+import com.grepp.spring.app.model.member.dto.MemberEmailSendResponse;
+import com.grepp.spring.app.model.member.dto.MemberEmailVerifyRequest;
+import com.grepp.spring.app.model.member.dto.MemberEmailVerifyResponse;
+import com.grepp.spring.app.model.member.dto.MemberPasswordFindRequest;
+import com.grepp.spring.app.model.member.dto.MemberPasswordFindResponse;
+import com.grepp.spring.app.model.member.dto.MemberPasswordResetRequest;
+import com.grepp.spring.app.model.member.dto.MemberPasswordResetResponse;
+import com.grepp.spring.app.model.member.dto.MemberMypageRequest;
+import com.grepp.spring.app.model.member.dto.MemberMypageResponse;
+import com.grepp.spring.app.model.member.dto.MemberProfileImageRequest;
+import com.grepp.spring.app.model.member.dto.MemberProfileImageResponse;
+import com.grepp.spring.app.model.member.dto.MemberGoalRequest;
+import com.grepp.spring.app.model.member.dto.MemberGoalResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+
+import java.util.List;
+import java.util.Map;
+
+// 멤버 로그인 Mock API 컨트롤러
+// 입력: MemberLoginRequest(email, password)
+// 출력: MemberLoginResponse(code, message, data)
+@RestController
+@RequestMapping(value = "/api/members", produces = MediaType.APPLICATION_JSON_VALUE)
+public class MemberMockController {
+    @PostMapping("/login")
+    public ResponseEntity<MemberLoginResponse> login(@RequestBody MemberLoginRequest request) {
+        // 하드코딩된 토큰 및 응답 데이터
+        MemberLoginResponse.Data data = new MemberLoginResponse.Data(
+                "mock-access-token",
+                "mock-refresh-token"
+        );
+        MemberLoginResponse response = new MemberLoginResponse(2000, "로그인에 성공하였습니다.", data);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<MemberSignupResponse> signup(@RequestBody MemberSignupRequest request) {
+        // 하드코딩된 회원가입 응답 데이터
+        MemberSignupResponse.Data data = new MemberSignupResponse.Data(1L);
+        MemberSignupResponse response = new MemberSignupResponse(2000, "회원가입이 완료되었습니다.", data);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<MemberLogoutResponse> logout(@RequestBody(required = false) MemberLogoutRequest request) {
+        // 하드코딩된 로그아웃 응답 데이터
+        MemberLogoutResponse response = new MemberLogoutResponse(2000, "로그아웃이 완료되었습니다.", null);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/email/send")
+    public ResponseEntity<MemberEmailSendResponse> sendEmailCode(@RequestBody MemberEmailSendRequest request) {
+        // 하드코딩된 이메일 인증(코드 발송) 응답 데이터
+        MemberEmailSendResponse response = new MemberEmailSendResponse(2000, "이메일 인증 코드가 발송되었습니다.", null);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/email/verify")
+    public ResponseEntity<MemberEmailVerifyResponse> verifyEmailCode(@RequestBody MemberEmailVerifyRequest request) {
+        // 하드코딩된 이메일 인증(코드 검증) 응답 데이터
+        MemberEmailVerifyResponse response = new MemberEmailVerifyResponse(2000, "이메일 인증이 완료되었습니다.", null);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/password/find")
+    public ResponseEntity<MemberPasswordFindResponse> findPassword(@RequestBody MemberPasswordFindRequest request) {
+        // 하드코딩된 비밀번호 찾기 응답 데이터
+        MemberPasswordFindResponse response = new MemberPasswordFindResponse(2000, "비밀번호 찾기 메일이 발송되었습니다.", null);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/password/reset")
+    public ResponseEntity<MemberPasswordResetResponse> resetPassword(@RequestBody MemberPasswordResetRequest request) {
+        // 하드코딩된 비밀번호 변경 응답 데이터
+        MemberPasswordResetResponse response = new MemberPasswordResetResponse(2000, "비밀번호가 변경되었습니다.", null);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/login/kakao")
+    public ResponseEntity<MemberLoginResponse> kakaoLogin(@RequestBody Map<String, String> request) {
+        // 하드코딩된 소셜 로그인(카카오) 응답 데이터
+        MemberLoginResponse.Data data = new MemberLoginResponse.Data(
+                "mock-kakao-access-token",
+                "mock-kakao-refresh-token"
+        );
+        MemberLoginResponse response = new MemberLoginResponse(2000, "카카오 로그인에 성공하였습니다.", data);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/mypage")
+    public ResponseEntity<MemberMypageResponse> getMypage() {
+        // 하드코딩된 마이페이지 조회 응답 데이터
+        MemberMypageRequest.MyPostDto post = new MemberMypageRequest.MyPostDto(1L, "첫 번째 글");
+        MemberMypageResponse.Data data = new MemberMypageResponse.Data(
+                "test@test.com", "테스트유저", "https://image.url", 1000000, 5, 1200, 2000, 60, List.of(post)
+        );
+        MemberMypageResponse response = new MemberMypageResponse(2000, "마이페이지 조회 성공", data);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/mypage")
+    public ResponseEntity<MemberMypageResponse> updateMypage(@RequestBody MemberMypageRequest request) {
+        // 하드코딩된 마이페이지 수정 응답 데이터
+        MemberMypageResponse.Data data = new MemberMypageResponse.Data(
+                "test@test.com", request.getName(), request.getProfileImage(), request.getGoalAmount(),
+                request.getLevel(), request.getCurrentExp(), request.getNextLevelExp(), request.getExpProgress(), request.getMyPosts()
+        );
+        MemberMypageResponse response = new MemberMypageResponse(2000, "마이페이지 수정 성공", data);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/profile-image")
+    public ResponseEntity<MemberProfileImageResponse> updateProfileImage(@RequestBody MemberProfileImageRequest request) {
+        // 하드코딩된 프로필 이미지 변경 응답 데이터
+        MemberProfileImageResponse response = new MemberProfileImageResponse(2000, "프로필 이미지가 변경되었습니다.", null);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/mypage/goal")
+    public ResponseEntity<MemberGoalResponse> setGoal(@RequestBody MemberGoalRequest request) {
+        // 하드코딩된 목표 설정 응답 데이터
+        MemberGoalResponse.Data data = new MemberGoalResponse.Data(request.getGoalAmount());
+        MemberGoalResponse response = new MemberGoalResponse(2000, "목표 금액이 설정되었습니다.", data);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<MemberLogoutResponse> deleteMember() {
+        // 하드코딩된 회원 탈퇴 응답 데이터 (로그아웃 응답 재사용)
+        MemberLogoutResponse response = new MemberLogoutResponse(2000, "회원 탈퇴가 완료되었습니다.", null);
+        return ResponseEntity.ok(response);
+    }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberMockController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberMockController.java
@@ -20,6 +20,10 @@ import com.grepp.spring.app.model.member.dto.MemberProfileImageRequest;
 import com.grepp.spring.app.model.member.dto.MemberProfileImageResponse;
 import com.grepp.spring.app.model.member.dto.MemberGoalRequest;
 import com.grepp.spring.app.model.member.dto.MemberGoalResponse;
+import com.grepp.spring.app.model.auth.AuthService;
+import com.grepp.spring.app.model.auth.dto.TokenDto;
+import com.grepp.spring.app.controller.api.auth.payload.LoginRequest;
+import com.grepp.spring.infra.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -41,111 +45,111 @@ import java.util.Map;
 @RequestMapping(value = "/api/members", produces = MediaType.APPLICATION_JSON_VALUE)
 public class MemberMockController {
     @PostMapping("/login")
-    public ResponseEntity<MemberLoginResponse> login(@RequestBody MemberLoginRequest request) {
+    public ResponseEntity<ApiResponse<MemberLoginResponse>> login(@RequestBody MemberLoginRequest request) {
         // 하드코딩된 토큰 및 응답 데이터
         MemberLoginResponse.Data data = new MemberLoginResponse.Data(
                 "mock-access-token",
                 "mock-refresh-token"
         );
         MemberLoginResponse response = new MemberLoginResponse(2000, "로그인에 성공하였습니다.", data);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @PostMapping("/signup")
-    public ResponseEntity<MemberSignupResponse> signup(@RequestBody MemberSignupRequest request) {
+    public ResponseEntity<ApiResponse<MemberSignupResponse>> signup(@RequestBody MemberSignupRequest request) {
         // 하드코딩된 회원가입 응답 데이터
         MemberSignupResponse.Data data = new MemberSignupResponse.Data(1L);
         MemberSignupResponse response = new MemberSignupResponse(2000, "회원가입이 완료되었습니다.", data);
-        return new ResponseEntity<>(response, HttpStatus.CREATED);
+        return new ResponseEntity<>(ApiResponse.success(response), HttpStatus.CREATED);
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<MemberLogoutResponse> logout(@RequestBody(required = false) MemberLogoutRequest request) {
+    public ResponseEntity<ApiResponse<MemberLogoutResponse>> logout(@RequestBody(required = false) MemberLogoutRequest request) {
         // 하드코딩된 로그아웃 응답 데이터
         MemberLogoutResponse response = new MemberLogoutResponse(2000, "로그아웃이 완료되었습니다.", null);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @PostMapping("/email/send")
-    public ResponseEntity<MemberEmailSendResponse> sendEmailCode(@RequestBody MemberEmailSendRequest request) {
+    public ResponseEntity<ApiResponse<MemberEmailSendResponse>> sendEmailCode(@RequestBody MemberEmailSendRequest request) {
         // 하드코딩된 이메일 인증(코드 발송) 응답 데이터
         MemberEmailSendResponse response = new MemberEmailSendResponse(2000, "이메일 인증 코드가 발송되었습니다.", null);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @PostMapping("/email/verify")
-    public ResponseEntity<MemberEmailVerifyResponse> verifyEmailCode(@RequestBody MemberEmailVerifyRequest request) {
+    public ResponseEntity<ApiResponse<MemberEmailVerifyResponse>> verifyEmailCode(@RequestBody MemberEmailVerifyRequest request) {
         // 하드코딩된 이메일 인증(코드 검증) 응답 데이터
         MemberEmailVerifyResponse response = new MemberEmailVerifyResponse(2000, "이메일 인증이 완료되었습니다.", null);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @PostMapping("/password/find")
-    public ResponseEntity<MemberPasswordFindResponse> findPassword(@RequestBody MemberPasswordFindRequest request) {
+    public ResponseEntity<ApiResponse<MemberPasswordFindResponse>> findPassword(@RequestBody MemberPasswordFindRequest request) {
         // 하드코딩된 비밀번호 찾기 응답 데이터
         MemberPasswordFindResponse response = new MemberPasswordFindResponse(2000, "비밀번호 찾기 메일이 발송되었습니다.", null);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @PostMapping("/password/reset")
-    public ResponseEntity<MemberPasswordResetResponse> resetPassword(@RequestBody MemberPasswordResetRequest request) {
+    public ResponseEntity<ApiResponse<MemberPasswordResetResponse>> resetPassword(@RequestBody MemberPasswordResetRequest request) {
         // 하드코딩된 비밀번호 변경 응답 데이터
         MemberPasswordResetResponse response = new MemberPasswordResetResponse(2000, "비밀번호가 변경되었습니다.", null);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @PostMapping("/login/kakao")
-    public ResponseEntity<MemberLoginResponse> kakaoLogin(@RequestBody Map<String, String> request) {
+    public ResponseEntity<ApiResponse<MemberLoginResponse>> kakaoLogin(@RequestBody Map<String, String> request) {
         // 하드코딩된 소셜 로그인(카카오) 응답 데이터
         MemberLoginResponse.Data data = new MemberLoginResponse.Data(
                 "mock-kakao-access-token",
                 "mock-kakao-refresh-token"
         );
         MemberLoginResponse response = new MemberLoginResponse(2000, "카카오 로그인에 성공하였습니다.", data);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @GetMapping("/mypage")
-    public ResponseEntity<MemberMypageResponse> getMypage() {
+    public ResponseEntity<ApiResponse<MemberMypageResponse>> getMypage() {
         // 하드코딩된 마이페이지 조회 응답 데이터
         MemberMypageRequest.MyPostDto post = new MemberMypageRequest.MyPostDto(1L, "첫 번째 글");
         MemberMypageResponse.Data data = new MemberMypageResponse.Data(
                 "test@test.com", "테스트유저", "https://image.url", 1000000, 5, 1200, 2000, 60, List.of(post)
         );
         MemberMypageResponse response = new MemberMypageResponse(2000, "마이페이지 조회 성공", data);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @PatchMapping("/mypage")
-    public ResponseEntity<MemberMypageResponse> updateMypage(@RequestBody MemberMypageRequest request) {
+    public ResponseEntity<ApiResponse<MemberMypageResponse>> updateMypage(@RequestBody MemberMypageRequest request) {
         // 하드코딩된 마이페이지 수정 응답 데이터
         MemberMypageResponse.Data data = new MemberMypageResponse.Data(
                 "test@test.com", request.getName(), request.getProfileImage(), request.getGoalAmount(),
                 request.getLevel(), request.getCurrentExp(), request.getNextLevelExp(), request.getExpProgress(), request.getMyPosts()
         );
         MemberMypageResponse response = new MemberMypageResponse(2000, "마이페이지 수정 성공", data);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @PatchMapping("/profile-image")
-    public ResponseEntity<MemberProfileImageResponse> updateProfileImage(@RequestBody MemberProfileImageRequest request) {
+    public ResponseEntity<ApiResponse<MemberProfileImageResponse>> updateProfileImage(@RequestBody MemberProfileImageRequest request) {
         // 하드코딩된 프로필 이미지 변경 응답 데이터
         MemberProfileImageResponse response = new MemberProfileImageResponse(2000, "프로필 이미지가 변경되었습니다.", null);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @PostMapping("/mypage/goal")
-    public ResponseEntity<MemberGoalResponse> setGoal(@RequestBody MemberGoalRequest request) {
+    public ResponseEntity<ApiResponse<MemberGoalResponse>> setGoal(@RequestBody MemberGoalRequest request) {
         // 하드코딩된 목표 설정 응답 데이터
         MemberGoalResponse.Data data = new MemberGoalResponse.Data(request.getGoalAmount());
         MemberGoalResponse response = new MemberGoalResponse(2000, "목표 금액이 설정되었습니다.", data);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @DeleteMapping
-    public ResponseEntity<MemberLogoutResponse> deleteMember() {
+    public ResponseEntity<ApiResponse<MemberLogoutResponse>> deleteMember() {
         // 하드코딩된 회원 탈퇴 응답 데이터 (로그아웃 응답 재사용)
         MemberLogoutResponse response = new MemberLogoutResponse(2000, "회원 탈퇴가 완료되었습니다.", null);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 } 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberEmailSendRequest.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberEmailSendRequest.java
@@ -1,0 +1,14 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 이메일 인증(코드 발송) 요청 DTO
+// 입력: email
+public class MemberEmailSendRequest {
+    private String email;
+
+    public MemberEmailSendRequest() {}
+    public MemberEmailSendRequest(String email) {
+        this.email = email;
+    }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberEmailSendResponse.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberEmailSendResponse.java
@@ -1,0 +1,22 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 이메일 인증(코드 발송) 응답 DTO
+// 출력: code, message, data(null)
+public class MemberEmailSendResponse {
+    private int code;
+    private String message;
+    private Object data;
+
+    public MemberEmailSendResponse() {}
+    public MemberEmailSendResponse(int code, String message, Object data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+    public int getCode() { return code; }
+    public void setCode(int code) { this.code = code; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public Object getData() { return data; }
+    public void setData(Object data) { this.data = data; }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberEmailVerifyRequest.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberEmailVerifyRequest.java
@@ -1,0 +1,18 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 이메일 인증(코드 검증) 요청 DTO
+// 입력: email, code
+public class MemberEmailVerifyRequest {
+    private String email;
+    private String code;
+
+    public MemberEmailVerifyRequest() {}
+    public MemberEmailVerifyRequest(String email, String code) {
+        this.email = email;
+        this.code = code;
+    }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberEmailVerifyResponse.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberEmailVerifyResponse.java
@@ -1,0 +1,22 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 이메일 인증(코드 검증) 응답 DTO
+// 출력: code, message, data(null)
+public class MemberEmailVerifyResponse {
+    private int code;
+    private String message;
+    private Object data;
+
+    public MemberEmailVerifyResponse() {}
+    public MemberEmailVerifyResponse(int code, String message, Object data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+    public int getCode() { return code; }
+    public void setCode(int code) { this.code = code; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public Object getData() { return data; }
+    public void setData(Object data) { this.data = data; }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberGoalRequest.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberGoalRequest.java
@@ -1,0 +1,14 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 목표 설정 요청 DTO
+// 입력: goalAmount
+public class MemberGoalRequest {
+    private int goalAmount;
+
+    public MemberGoalRequest() {}
+    public MemberGoalRequest(int goalAmount) {
+        this.goalAmount = goalAmount;
+    }
+    public int getGoalAmount() { return goalAmount; }
+    public void setGoalAmount(int goalAmount) { this.goalAmount = goalAmount; }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberGoalResponse.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberGoalResponse.java
@@ -1,0 +1,30 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 목표 설정 응답 DTO
+// 출력: code, message, data(goalAmount)
+public class MemberGoalResponse {
+    private int code;
+    private String message;
+    private Data data;
+
+    public static class Data {
+        private int goalAmount;
+        public Data() {}
+        public Data(int goalAmount) { this.goalAmount = goalAmount; }
+        public int getGoalAmount() { return goalAmount; }
+        public void setGoalAmount(int goalAmount) { this.goalAmount = goalAmount; }
+    }
+
+    public MemberGoalResponse() {}
+    public MemberGoalResponse(int code, String message, Data data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+    public int getCode() { return code; }
+    public void setCode(int code) { this.code = code; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public Data getData() { return data; }
+    public void setData(Data data) { this.data = data; }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberLoginRequest.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberLoginRequest.java
@@ -1,0 +1,18 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 멤버 로그인 요청 DTO
+// 입력: email, password
+public class MemberLoginRequest {
+    private String email;
+    private String password;
+
+    public MemberLoginRequest() {}
+    public MemberLoginRequest(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberLoginResponse.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberLoginResponse.java
@@ -1,0 +1,36 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 멤버 로그인 응답 DTO
+// 출력: code, message, data(accessToken, refreshToken)
+public class MemberLoginResponse {
+    private int code;
+    private String message;
+    private Data data;
+
+    public MemberLoginResponse() {}
+    public MemberLoginResponse(int code, String message, Data data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+    public int getCode() { return code; }
+    public void setCode(int code) { this.code = code; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public Data getData() { return data; }
+    public void setData(Data data) { this.data = data; }
+
+    public static class Data {
+        private String accessToken;
+        private String refreshToken;
+        public Data() {}
+        public Data(String accessToken, String refreshToken) {
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
+        }
+        public String getAccessToken() { return accessToken; }
+        public void setAccessToken(String accessToken) { this.accessToken = accessToken; }
+        public String getRefreshToken() { return refreshToken; }
+        public void setRefreshToken(String refreshToken) { this.refreshToken = refreshToken; }
+    }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberLogoutRequest.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberLogoutRequest.java
@@ -1,0 +1,6 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 로그아웃 요청 DTO
+public class MemberLogoutRequest {
+    // 로그아웃은 별도의 요청 필드가 없습니다.
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberLogoutResponse.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberLogoutResponse.java
@@ -1,0 +1,22 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 로그아웃 응답 DTO
+// 출력: code, message, data(null)
+public class MemberLogoutResponse {
+    private int code;
+    private String message;
+    private Object data;
+
+    public MemberLogoutResponse() {}
+    public MemberLogoutResponse(int code, String message, Object data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+    public int getCode() { return code; }
+    public void setCode(int code) { this.code = code; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public Object getData() { return data; }
+    public void setData(Object data) { this.data = data; }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberMypageRequest.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberMypageRequest.java
@@ -1,0 +1,59 @@
+package com.grepp.spring.app.model.member.dto;
+
+import java.util.List;
+
+// 마이페이지 수정 요청 DTO
+// 입력: name, profileImage, goalAmount, level, currentExp, nextLevelExp, expProgress, myPosts
+public class MemberMypageRequest {
+    private String name;
+    private String profileImage;
+    private int goalAmount;
+    private int level;
+    private int currentExp;
+    private int nextLevelExp;
+    private int expProgress;
+    private List<MyPostDto> myPosts;
+
+    // MyPostDto 내부 클래스 정의
+    public static class MyPostDto {
+        private Long postId;
+        private String title;
+        public MyPostDto() {}
+        public MyPostDto(Long postId, String title) {
+            this.postId = postId;
+            this.title = title;
+        }
+        public Long getPostId() { return postId; }
+        public void setPostId(Long postId) { this.postId = postId; }
+        public String getTitle() { return title; }
+        public void setTitle(String title) { this.title = title; }
+    }
+
+    public MemberMypageRequest() {}
+    public MemberMypageRequest(String name, String profileImage, int goalAmount, int level, int currentExp, int nextLevelExp, int expProgress, List<MyPostDto> myPosts) {
+        this.name = name;
+        this.profileImage = profileImage;
+        this.goalAmount = goalAmount;
+        this.level = level;
+        this.currentExp = currentExp;
+        this.nextLevelExp = nextLevelExp;
+        this.expProgress = expProgress;
+        this.myPosts = myPosts;
+    }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getProfileImage() { return profileImage; }
+    public void setProfileImage(String profileImage) { this.profileImage = profileImage; }
+    public int getGoalAmount() { return goalAmount; }
+    public void setGoalAmount(int goalAmount) { this.goalAmount = goalAmount; }
+    public int getLevel() { return level; }
+    public void setLevel(int level) { this.level = level; }
+    public int getCurrentExp() { return currentExp; }
+    public void setCurrentExp(int currentExp) { this.currentExp = currentExp; }
+    public int getNextLevelExp() { return nextLevelExp; }
+    public void setNextLevelExp(int nextLevelExp) { this.nextLevelExp = nextLevelExp; }
+    public int getExpProgress() { return expProgress; }
+    public void setExpProgress(int expProgress) { this.expProgress = expProgress; }
+    public List<MyPostDto> getMyPosts() { return myPosts; }
+    public void setMyPosts(List<MyPostDto> myPosts) { this.myPosts = myPosts; }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberMypageResponse.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberMypageResponse.java
@@ -1,0 +1,66 @@
+package com.grepp.spring.app.model.member.dto;
+
+import java.util.List;
+
+// 마이페이지 조회 응답 DTO
+// 출력: code, message, data(마이페이지 정보)
+public class MemberMypageResponse {
+    private int code;
+    private String message;
+    private Data data;
+
+    public static class Data {
+        private String email;
+        private String name;
+        private String profileImage;
+        private int goalAmount;
+        private int level;
+        private int currentExp;
+        private int nextLevelExp;
+        private int expProgress;
+        private List<MemberMypageRequest.MyPostDto> myPosts;
+        public Data() {}
+        public Data(String email, String name, String profileImage, int goalAmount, int level, int currentExp, int nextLevelExp, int expProgress, List<MemberMypageRequest.MyPostDto> myPosts) {
+            this.email = email;
+            this.name = name;
+            this.profileImage = profileImage;
+            this.goalAmount = goalAmount;
+            this.level = level;
+            this.currentExp = currentExp;
+            this.nextLevelExp = nextLevelExp;
+            this.expProgress = expProgress;
+            this.myPosts = myPosts;
+        }
+        public String getEmail() { return email; }
+        public void setEmail(String email) { this.email = email; }
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+        public String getProfileImage() { return profileImage; }
+        public void setProfileImage(String profileImage) { this.profileImage = profileImage; }
+        public int getGoalAmount() { return goalAmount; }
+        public void setGoalAmount(int goalAmount) { this.goalAmount = goalAmount; }
+        public int getLevel() { return level; }
+        public void setLevel(int level) { this.level = level; }
+        public int getCurrentExp() { return currentExp; }
+        public void setCurrentExp(int currentExp) { this.currentExp = currentExp; }
+        public int getNextLevelExp() { return nextLevelExp; }
+        public void setNextLevelExp(int nextLevelExp) { this.nextLevelExp = nextLevelExp; }
+        public int getExpProgress() { return expProgress; }
+        public void setExpProgress(int expProgress) { this.expProgress = expProgress; }
+        public List<MemberMypageRequest.MyPostDto> getMyPosts() { return myPosts; }
+        public void setMyPosts(List<MemberMypageRequest.MyPostDto> myPosts) { this.myPosts = myPosts; }
+    }
+
+    public MemberMypageResponse() {}
+    public MemberMypageResponse(int code, String message, Data data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+    public int getCode() { return code; }
+    public void setCode(int code) { this.code = code; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public Data getData() { return data; }
+    public void setData(Data data) { this.data = data; }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberPasswordFindRequest.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberPasswordFindRequest.java
@@ -1,0 +1,14 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 비밀번호 찾기 요청 DTO
+// 입력: email
+public class MemberPasswordFindRequest {
+    private String email;
+
+    public MemberPasswordFindRequest() {}
+    public MemberPasswordFindRequest(String email) {
+        this.email = email;
+    }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberPasswordFindResponse.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberPasswordFindResponse.java
@@ -1,0 +1,22 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 비밀번호 찾기 응답 DTO
+// 출력: code, message, data(null)
+public class MemberPasswordFindResponse {
+    private int code;
+    private String message;
+    private Object data;
+
+    public MemberPasswordFindResponse() {}
+    public MemberPasswordFindResponse(int code, String message, Object data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+    public int getCode() { return code; }
+    public void setCode(int code) { this.code = code; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public Object getData() { return data; }
+    public void setData(Object data) { this.data = data; }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberPasswordResetRequest.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberPasswordResetRequest.java
@@ -1,0 +1,18 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 비밀번호 변경 요청 DTO
+// 입력: email, newPassword
+public class MemberPasswordResetRequest {
+    private String email;
+    private String newPassword;
+
+    public MemberPasswordResetRequest() {}
+    public MemberPasswordResetRequest(String email, String newPassword) {
+        this.email = email;
+        this.newPassword = newPassword;
+    }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getNewPassword() { return newPassword; }
+    public void setNewPassword(String newPassword) { this.newPassword = newPassword; }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberPasswordResetResponse.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberPasswordResetResponse.java
@@ -1,0 +1,22 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 비밀번호 변경 응답 DTO
+// 출력: code, message, data(null)
+public class MemberPasswordResetResponse {
+    private int code;
+    private String message;
+    private Object data;
+
+    public MemberPasswordResetResponse() {}
+    public MemberPasswordResetResponse(int code, String message, Object data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+    public int getCode() { return code; }
+    public void setCode(int code) { this.code = code; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public Object getData() { return data; }
+    public void setData(Object data) { this.data = data; }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberProfileImageRequest.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberProfileImageRequest.java
@@ -1,0 +1,14 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 프로필 이미지 변경 요청 DTO
+// 입력: imageUrl
+public class MemberProfileImageRequest {
+    private String imageUrl;
+
+    public MemberProfileImageRequest() {}
+    public MemberProfileImageRequest(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+    public String getImageUrl() { return imageUrl; }
+    public void setImageUrl(String imageUrl) { this.imageUrl = imageUrl; }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberProfileImageResponse.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberProfileImageResponse.java
@@ -1,0 +1,22 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 프로필 이미지 변경 응답 DTO
+// 출력: code, message, data(null)
+public class MemberProfileImageResponse {
+    private int code;
+    private String message;
+    private Object data;
+
+    public MemberProfileImageResponse() {}
+    public MemberProfileImageResponse(int code, String message, Object data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+    public int getCode() { return code; }
+    public void setCode(int code) { this.code = code; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public Object getData() { return data; }
+    public void setData(Object data) { this.data = data; }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberSignupRequest.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberSignupRequest.java
@@ -1,0 +1,22 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 회원가입 요청 DTO
+// 입력: email, password, name
+public class MemberSignupRequest {
+    private String email;
+    private String password;
+    private String name;
+
+    public MemberSignupRequest() {}
+    public MemberSignupRequest(String email, String password, String name) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+    }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberSignupResponse.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/dto/MemberSignupResponse.java
@@ -1,0 +1,30 @@
+package com.grepp.spring.app.model.member.dto;
+
+// 회원가입 응답 DTO
+// 출력: code, message, data(userId)
+public class MemberSignupResponse {
+    private int code;
+    private String message;
+    private Data data;
+
+    public MemberSignupResponse() {}
+    public MemberSignupResponse(int code, String message, Data data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+    public int getCode() { return code; }
+    public void setCode(int code) { this.code = code; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public Data getData() { return data; }
+    public void setData(Data data) { this.data = data; }
+
+    public static class Data {
+        private Long userId;
+        public Data() {}
+        public Data(Long userId) { this.userId = userId; }
+        public Long getUserId() { return userId; }
+        public void setUserId(Long userId) { this.userId = userId; }
+    }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
                 (requests) -> requests
                                   .requestMatchers("/favicon.ico", "/img/**", "/js/**","/css/**").permitAll()
                                   .requestMatchers("/", "/error", "/auth/login", "/auth/signup").permitAll()
+                                  .requestMatchers("/api/members/login").permitAll()
                                   .requestMatchers("/api/**").authenticated()
                                   .anyRequest().permitAll()
             )


### PR DESCRIPTION
회원/마이페이지 도메인 전반에 대해 Mock API 구현 및 코드 정비

✨ 회원/인증 기능 Mock API
회원/인증 Mock API 개발
	•	회원가입: /api/members/signup
	•	로그인: /api/members/login
	•	로그아웃: /api/members/logout
	•	이메일 인증 코드 발송/검증: /api/members/email/send, /api/members/email/verify
	•	비밀번호 찾기/재설정: /api/members/password/find, /api/members/password/reset
	•	카카오 소셜 로그인: /api/members/login/kakao

마이페이지/프로필/목표 Mock API 개발
	•	마이페이지 조회/수정: /api/members/mypage (GET/PATCH)
	•	프로필 이미지 변경: /api/members/profile-image
	•	목표 금액 설정: /api/members/mypage/goal
	•	회원 탈퇴: /api/members (DELETE)

DTO/컨트롤러/도메인 구조 정비
	•	DTO 클래스 도메인별 패키지로 이동
	•	컨트롤러 통합: MemberMockController 에서 일괄 관리


📦 공통/구조 정비
각 API별 Request/Response DTO → dto 패키지로 이동
MemberMockController 에서 모든 회원/마이페이지/목표 관련 엔드포인트 관리
SecurityConfig 에서 /api/members/login 접근 허용 추가
