### PR TITLE
feat: 관리자 Mock API 및 DTO 구현

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/admin/AdminStatsController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/admin/AdminStatsController.java
@@ -1,0 +1,27 @@
+package com.grepp.spring.app.controller.api.admin;
+
+import com.grepp.spring.app.model.admin.dto.AdminStatsResponse;
+import com.grepp.spring.infra.response.ApiResponse;
+import com.grepp.spring.infra.response.ResponseCode;
+import io.swagger.v3.oas.annotations.Operation;
+import java.time.LocalDate;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/admin-stats", produces = MediaType.APPLICATION_JSON_VALUE)
+public class AdminStatsController {
+
+    @GetMapping("/daily-stats")
+    @Operation(summary = "관리자 당일 통계(방문자, 회원가입 수) 조회")
+    public ResponseEntity<ApiResponse<AdminStatsResponse>> getDailyStats() {
+        return ResponseEntity
+            .status(ResponseCode.OK.status())
+            .body(ApiResponse.success(
+                new AdminStatsResponse(LocalDate.now().toString(), 100, 10)
+            ));
+    }
+}

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/admin/AdminStoreController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/admin/AdminStoreController.java
@@ -1,0 +1,137 @@
+package com.grepp.spring.app.controller.api.admin;
+
+import com.grepp.spring.app.model.admin.dto.AdminStoreCreateRequest;
+import com.grepp.spring.app.model.admin.dto.AdminStoreMenuResponse;
+import com.grepp.spring.app.model.admin.dto.AdminStoreResponse;
+import com.grepp.spring.app.model.admin.dto.AdminStoreUpdateRequest;
+import com.grepp.spring.infra.response.ApiResponse;
+import com.grepp.spring.infra.response.ResponseCode;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/admin-stores", produces = MediaType.APPLICATION_JSON_VALUE)
+public class AdminStoreController {
+
+    List<AdminStoreResponse> mockStores = List.of(
+        new AdminStoreResponse(
+            0,
+            "대박 대패삼겹&우삼겹",
+            "서울 송파구 천호대로152길 11-1",
+            "한식",
+            List.of(
+                new AdminStoreMenuResponse("삼겹살(100g)", 4500),
+                new AdminStoreMenuResponse("우삼겹(100g)", 4500),
+                new AdminStoreMenuResponse("대패삼겹살(100g)", 4500)
+            )
+        ),
+
+        new AdminStoreResponse(
+            1,
+            "고덕옛날손짜장",
+            "서울특별시 서울 강동구 동남로85길 36, 1층",
+            "중식",
+            List.of(
+                new AdminStoreMenuResponse("대패삼겹살", 4500),
+                new AdminStoreMenuResponse("우삼겹", 4500)
+            )
+        ),
+
+        new AdminStoreResponse(
+            2,
+            "하늘정원 수제왕돈까스",
+            "서울특별시 서대문구 거북골로 53-6, 1층(남가좌동)",
+            "일식",
+            List.of(
+                new AdminStoreMenuResponse("기계짜장", 5000)
+            )
+        )
+    );
+
+    @GetMapping
+    @Operation(summary = "관리자 모든 장소 조회")
+    public ResponseEntity<ApiResponse<List<AdminStoreResponse>>> getAllStores() {
+        return ResponseEntity
+            .status(ResponseCode.OK.status())
+            .body(ApiResponse.success(mockStores));
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "관리자 카테고리별 장소 조회")
+    public ResponseEntity<ApiResponse<List<AdminStoreResponse>>> searchByCategory(@RequestParam String category) {
+        if (!List.of("한식", "중식", "일식", "양식", "미용업", "세탁업", "숙박업").contains(category)) {
+            return ResponseEntity
+                .status(ResponseCode.BAD_REQUEST.status())
+                .body(ApiResponse.error(ResponseCode.BAD_REQUEST));
+        }
+
+        List<AdminStoreResponse> result = mockStores.stream()
+            .filter(p -> p.category().equals(category))
+            .toList();
+
+        return ResponseEntity
+            .status(ResponseCode.OK.status())
+            .body(ApiResponse.success(result));
+    }
+
+    @PostMapping
+    @Operation(summary = "관리자 장소 등록")
+    public ResponseEntity<ApiResponse<Map<String, String>>> createStore(@RequestBody @Valid AdminStoreCreateRequest request) {
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "장소 등록이 완료되었습니다");
+
+        return ResponseEntity
+            .status(ResponseCode.CREATED.status())
+            .body(ApiResponse.successToCreate(response));
+    }
+
+    @PatchMapping("/{store-id}")
+    @Operation(summary = "관리자 장소 수정")
+    public ResponseEntity<ApiResponse<Map<String, String>>> updateStore(
+        @PathVariable("store-id") int id,
+        @RequestBody AdminStoreUpdateRequest request) {
+        if(id != 0 && id != 1 && id !=2){
+            return ResponseEntity
+                .status(ResponseCode.NOT_FOUND.status())
+                .body(ApiResponse.error(ResponseCode.NOT_FOUND));
+        }
+
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "장소가 수정되었습니다.");
+
+        return ResponseEntity
+            .status(ResponseCode.OK.status())
+            .body(ApiResponse.success(response));
+    }
+
+    @PatchMapping("/{store-id}/delete")
+    @Operation(summary = "관리자 장소 삭제")
+    public ResponseEntity<ApiResponse<Map<String, String>>> deleteStore(@PathVariable("store-id") int id) {
+
+        if(id != 0 && id != 1 && id !=2){
+            return ResponseEntity
+                .status(ResponseCode.NOT_FOUND.status())
+                .body(ApiResponse.error(ResponseCode.NOT_FOUND));
+        }
+
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "장소가 삭제되었습니다.");
+
+        return ResponseEntity
+            .status(ResponseCode.OK.status())
+            .body(ApiResponse.success(response));
+    }
+}

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/admin/AdminUsersController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/admin/AdminUsersController.java
@@ -1,0 +1,73 @@
+package com.grepp.spring.app.controller.api.admin;
+
+import com.grepp.spring.app.model.admin.dto.AdminUserResponse;
+import com.grepp.spring.infra.response.ApiResponse;
+import com.grepp.spring.infra.response.ResponseCode;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/admin-users", produces = MediaType.APPLICATION_JSON_VALUE)
+public class AdminUsersController {
+
+    List<AdminUserResponse> mockUsers = List.of(
+        new AdminUserResponse(0, "거지왕", "abc@abc.com", false),
+        new AdminUserResponse(1, "부자왕", "def@def.com", false)
+    );
+
+    @GetMapping
+    @Operation(summary = "관리자 모든 회원 조회")
+    public ResponseEntity<ApiResponse<List<AdminUserResponse>>> getAllUsers() {
+        return ResponseEntity
+            .status(ResponseCode.OK.status())
+            .body(ApiResponse.success(mockUsers));
+    }
+
+
+    @GetMapping("/search")
+    @Operation(summary = "관리자 유저 닉네임으로 유저 검색")
+    public ResponseEntity<ApiResponse<List<AdminUserResponse>>> searchByNickname(@RequestParam String nickname) {
+        List<AdminUserResponse> result = mockUsers.stream()
+            .filter(user -> user.nickname().equals(nickname))
+            .toList();
+
+        if (result.isEmpty()) {
+            return ResponseEntity
+                .status(ResponseCode.NOT_FOUND.status())
+                .body(ApiResponse.error(ResponseCode.NOT_FOUND));
+        }
+
+        return ResponseEntity
+            .status(ResponseCode.OK.status())
+            .body(ApiResponse.success(result));
+    }
+
+    @PatchMapping("/{user-id}/block")
+    @Operation(summary = "관리자 유저 차단")
+    public ResponseEntity<ApiResponse<Map<String, String>>> blockUser(@PathVariable("user-id") int id) {
+
+        if(id != 1 && id != 2){
+            return ResponseEntity
+                .status(ResponseCode.NOT_FOUND.status())
+                .body(ApiResponse.error(ResponseCode.NOT_FOUND));
+        }
+
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "유저가 차단되었습니다.");
+
+        return ResponseEntity
+            .status(ResponseCode.OK.status())
+            .body(ApiResponse.success(response));
+    }
+
+}

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/admin/dto/AdminStatsResponse.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/admin/dto/AdminStatsResponse.java
@@ -1,0 +1,19 @@
+package com.grepp.spring.app.model.admin.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관리자 당일 통계(방문자, 회원가입 수) 조회 응답 DTO")
+public record AdminStatsResponse(
+
+    @Schema(description = "날짜", example = "2025-07-03")
+    String date,
+
+    @Schema(description = "방문자 수", example = "100")
+    int visitorCount,
+
+    @Schema(description = "회원가입 수", example = "10")
+    int signupCount
+
+) {
+
+}

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/admin/dto/AdminStoreCreateRequest.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/admin/dto/AdminStoreCreateRequest.java
@@ -1,0 +1,27 @@
+package com.grepp.spring.app.model.admin.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+@Schema(description = "장소 등록 용청 DTO")
+public record AdminStoreCreateRequest(
+
+    @Schema(description = "가게 이름", example = "대박 대패삼겹&우삼겹")
+    @NotBlank(message = "가게 이름은 필수입니다.")
+    String name,
+
+    @Schema(description = "가게 주소", example = "서울특별시 서울 송파구 천호대로152길 11-1")
+    @NotBlank(message = "가게 주소는 필수입니다.")
+    String address,
+
+    @Schema(description = "가게 카테고리", example = "한식")
+    @NotBlank(message = "카테고리는 필수입니다.")
+    String category,
+
+    @Schema(description = "메뉴 목록")
+    List<AdminStoreMenuResponse> menus
+
+    ) {
+
+}

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/admin/dto/AdminStoreMenuResponse.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/admin/dto/AdminStoreMenuResponse.java
@@ -1,0 +1,16 @@
+package com.grepp.spring.app.model.admin.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관리자 가게 메뉴 응답 DTO")
+public record AdminStoreMenuResponse(
+
+    @Schema(description = "메뉴 이름", example = "대패삼겹살")
+    String name,
+
+    @Schema(description = "메뉴 가격", example = "4500")
+    int price
+
+    ) {
+
+}

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/admin/dto/AdminStoreResponse.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/admin/dto/AdminStoreResponse.java
@@ -1,0 +1,26 @@
+package com.grepp.spring.app.model.admin.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "관리자 가게 응답 DTO")
+public record AdminStoreResponse(
+
+    @Schema(description = "가게 고유식별번호", example = "0")
+    int placeId,
+
+    @Schema(description = "가게 이름", example = "대박 대패삼겹&우삼겹")
+    String name,
+
+    @Schema(description = "가게 주소", example = "서울특별시 서울 송파구 천호대로152길 11-1")
+    String address,
+
+    @Schema(description = "가게 카테고리", example = "한식")
+    String category,
+
+    @Schema(description = "메뉴 목록")
+    List<AdminStoreMenuResponse> menus
+
+    ) {
+
+}

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/admin/dto/AdminStoreUpdateRequest.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/admin/dto/AdminStoreUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.grepp.spring.app.model.admin.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "장소 수정 용청 DTO")
+public record AdminStoreUpdateRequest(
+
+    @Schema(description = "가게 이름", example = "대박 대패삼겹&우삼겹")
+    String name,
+
+    @Schema(description = "가게 주소", example = "서울특별시 서울 송파구 천호대로152길 11-1")
+    String address,
+
+    @Schema(description = "가게 카테고리", example = "한식")
+    String category,
+
+    @Schema(description = "메뉴 목록")
+    List<AdminStoreResponse> menus
+
+) {
+
+}

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/admin/dto/AdminUserResponse.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/admin/dto/AdminUserResponse.java
@@ -1,0 +1,21 @@
+package com.grepp.spring.app.model.admin.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관리자 유저 응답 DTO")
+public record AdminUserResponse(
+
+    @Schema(description = "유저 고유식별번호", example = "0")
+    int userId,
+
+    @Schema(description = "닉네임", example = "거지왕")
+    String nickname,
+
+    @Schema(description = "이메일", example = "abc@abc.com")
+    String email,
+
+    @Schema(description = "차단여부", example = "false")
+    boolean activated
+) {
+
+}

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/response/ApiResponse.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/response/ApiResponse.java
@@ -14,6 +14,10 @@ public record ApiResponse<T>(
     public static <T> ApiResponse<T> success(T data) {
         return new ApiResponse<>(ResponseCode.OK.code(), ResponseCode.OK.message(), data);
     }
+
+    public static <T> ApiResponse<T> successToCreate(T data) {
+        return new ApiResponse<>(ResponseCode.CREATED.code(), ResponseCode.CREATED.message(), data);
+    }
     
     public static <T> ApiResponse<T> noContent() {
         return new ApiResponse<>(ResponseCode.OK.code(), ResponseCode.OK.message(), null);

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/response/ResponseCode.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/response/ResponseCode.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 
 public enum ResponseCode {
     OK("0000", HttpStatus.OK, "정상적으로 완료되었습니다."),
+    CREATED("0001", HttpStatus.CREATED, "정상적으로 추가되었습니다."),
     BAD_REQUEST("4000", HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     INVALID_FILENAME("4001", HttpStatus.BAD_REQUEST, "사용 할 수 없는 파일 이름입니다."),
     UNAUTHORIZED("4010", HttpStatus.UNAUTHORIZED, "권한이 없습니다."),


### PR DESCRIPTION
관리자 도메인의 Mock API 및 DTO 구현

✨ 관리자 기능 Mock API
- 관리자 모든 회원 조회 : (GET) /api/admin-users
- 관리자 유저 닉네임으로 유저 검색 : (GET) /api/admin-users/search?nickname={nickname}
- 관리자 유저 차단 : (PATCH) /api/admin-users/{user-id}/block
- 관리자 모든 장소 조회 : (GET) /api/admin-stores
- 관리자 카테고리별 장소 조회 : (GET) /api/admin-stores/search?category={category}
- 관리자 장소 등록 : (POST) /api/admin-stores
- 관리자 장소 수정 : (PATCH) /api/admin-stores/{store-id}
- 관리자 장소 삭제 : (PATCH) /api/admin-stores/{store-id}/delete
- 관리자 당일 통계 조회 : (GET) /api/admin-stats/daily-stats

📦 공통/구조 정비
- API 별로 필요한 dto 정의
- 관리자 회원 관리, 장소 관리, 통계 조회로 컨트롤러 분할