### PR TITLE
feat: [회원가입/로그인] 로그인 DTO 및 Swagger 예시 개선

### DIFF
--- a/apimocking-main/apimocking-boilerplate/.gitignore
+++ b/apimocking-main/apimocking-boilerplate/.gitignore
@@ -48,6 +48,7 @@ Thumbs.db
 application.properties
 application-local.properties
 application-prod.properties
+application-mock.properties
 
 # Environment files
 .env

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import com.grepp.spring.app.model.auth.AuthService;
 import com.grepp.spring.app.model.auth.dto.TokenDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @RestController
 @RequestMapping("/api/members")
@@ -79,6 +80,7 @@ public class MemberController {
     // 로그인
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody @Valid LoginRequest request) {
+        System.out.println("로그인 시도: email=" + request.getEmail() + ", password=" + request.getPassword());
         // AuthService의 signin을 사용하여 JWT 토큰 발급
         com.grepp.spring.app.controller.api.mock.auth.payload.LoginRequest authRequest = new com.grepp.spring.app.controller.api.mock.auth.payload.LoginRequest();
         authRequest.setUsername(request.getEmail());
@@ -127,7 +129,9 @@ public class MemberController {
     }
     @Getter @Setter @NoArgsConstructor @AllArgsConstructor
     public static class LoginRequest {
+        @Schema(description = "이메일", example = "test3@test.com")
         private String email;
+        @Schema(description = "비밀번호", example = "string")
         private String password;
     }
     @Getter @Setter @NoArgsConstructor @AllArgsConstructor

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/auth/jwt/TokenCookieFactory.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/auth/jwt/TokenCookieFactory.java
@@ -8,8 +8,8 @@ public class TokenCookieFactory {
                    .maxAge(expires)
                    .path("/")
                    .httpOnly(true)             // HttpOnly
-                   .secure(false)
-                   .sameSite("Lax")// Secure
+                   .secure(true)
+                   .sameSite("none")// Secure
                    .build();
     }
     
@@ -18,8 +18,8 @@ public class TokenCookieFactory {
                    .maxAge(0)
                    .path("/")
                    .httpOnly(true)             // HttpOnly
-                   .secure(false)
-                   .sameSite("Lax")// // Secure
+                   .secure(true)
+                   .sameSite("none")// // Secure
                    .build();
     }
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/config/WebConfig.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/config/WebConfig.java
@@ -14,7 +14,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-            .allowedOrigins(frontServer)
+            .allowedOrigins(frontServer, "http://localhost:3000")
             .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
             .allowedHeaders("*")
             .allowCredentials(true)

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
                 (requests) -> requests
                                   .requestMatchers("/favicon.ico", "/img/**", "/js/**","/css/**").permitAll()
                                   .requestMatchers("/", "/error", "/auth/login", "/auth/signup").permitAll()
-                                  .requestMatchers("/api/members/login").permitAll()
+                                  .requestMatchers("/api/members/login", "/api/members/signup").permitAll()
                                   .requestMatchers("/api/**").authenticated()
                                   .anyRequest().permitAll()
             )

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/config/security/SecurityConfigMock.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/config/security/SecurityConfigMock.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -18,4 +20,8 @@ public class SecurityConfigMock {
             .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
         return http.build();
     }
-} 
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}


### PR DESCRIPTION
### 주요 변경사항

1. 로그인 DTO 및 Swagger 예시 개선
   - 로그인 요청 DTO(LoginRequest) 필드명을 email로 명확히 유지
   - Swagger 문서에서 Request Body 예시가 username이 아니라 email로 노출되도록 @Schema 어노테이션 추가

2. 로그인 입력값 디버깅 로그 추가
   - 로그인 시도 시 입력값(email, password)을 콘솔에 출력하는 로그 추가

3. 토큰 쿠키 전송 설정 수정

4. 기타
   - 불필요한 mock 컨트롤러/설정 정리
