### PR TITLE
fix: JWT subject 및 인증 기준을 memberId에서 email로 일원화

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/auth/domain/Principal.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/auth/domain/Principal.java
@@ -19,7 +19,7 @@ public class Principal extends User {
     
     public static Principal createPrincipal(Member member,
         List<SimpleGrantedAuthority> authorities){
-        return new Principal(member.getMemberId().toString(), member.getPassword(), authorities);
+        return new Principal(member.getEmail(), member.getPassword(), authorities);
     }
     
     public Optional<String> getAccessToken() {


### PR DESCRIPTION
Principal.createPrincipal에서 subject로 memberId 대신 email 사용
- JWT 토큰의 subject가 항상 이메일이 되도록 수정
- UserDetailsServiceImpl, 인증 처리 전반이 이메일 기준으로 일관되게 동작
- 인증이 필요한 API 호출 시 500 에러(UsernameNotFoundException) 발생 문제 해결