### PR TITLE
feat: notification 테이블에 senderId, type 필드 추가

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/mock/member/MemberMockController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/mock/member/MemberMockController.java
@@ -155,8 +155,12 @@ public class MemberMockController {
     public ResponseEntity<ApiResponse<MemberMypageResponse>> getMypage() {
         // 마이페이지 조회 Mock 응답
         MemberMypageRequest.MyPostDto post = new MemberMypageRequest.MyPostDto(1L, "첫 번째 글");
+        MemberMypageResponse.BookmarkedPostDto bookmarkedPost = new MemberMypageResponse.BookmarkedPostDto(2L, "나만의 가성비 장소");
+        MemberMypageResponse.BookmarkedPlaceDto bookmarkedPlace = new MemberMypageResponse.BookmarkedPlaceDto(1L, "착한식당");
         MemberMypageResponse.Data data = new MemberMypageResponse.Data(
-                1, "test@test.com", "테스트유저", "https://image.url", 1000000, 5, 1200, 2000, 60, List.of(post)
+                1, "test@test.com", "테스트유저", "https://image.url", 5, 1200, 2000, 60, List.of(post),
+                "자동차", new java.math.BigDecimal("10000"),
+                List.of(bookmarkedPost), List.of(bookmarkedPlace)
         );
         MemberMypageResponse response = new MemberMypageResponse(2000, "마이페이지 조회 성공", data);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -166,8 +170,10 @@ public class MemberMockController {
     public ResponseEntity<ApiResponse<MemberMypageResponse>> updateMypage(@RequestBody MemberMypageRequest request) {
         // 마이페이지 수정 Mock 응답
         MemberMypageResponse.Data data = new MemberMypageResponse.Data(
-                1,"test@test.com", request.getName(), request.getProfileImage(), request.getGoalAmount(),
-                request.getLevel(), request.getCurrentExp(), request.getNextLevelExp(), request.getExpProgress(), request.getMyPosts()
+                1,"test@test.com", request.getName(), request.getProfileImage(),
+                request.getLevel(), request.getCurrentExp(), request.getNextLevelExp(), request.getExpProgress(), request.getMyPosts(),
+                request.getGoalStuff(), request.getRemainPrice(),
+                request.getBookmarkedPosts(), request.getBookmarkedPlaces()
         );
         MemberMypageResponse response = new MemberMypageResponse(2000, "마이페이지 수정 성공", data);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -362,12 +368,15 @@ public class MemberMockController {
     public static class MemberMypageRequest {
         private String name;
         private String profileImage;
-        private int goalAmount;
         private int level;
         private int currentExp;
         private int nextLevelExp;
         private int expProgress;
         private List<MyPostDto> myPosts;
+        private String goalStuff; // ex) "자동차"
+        private java.math.BigDecimal remainPrice; // ex) 10000
+        private List<MemberMypageResponse.BookmarkedPostDto> bookmarkedPosts;
+        private List<MemberMypageResponse.BookmarkedPlaceDto> bookmarkedPlaces;
         
         @Getter
         @Setter
@@ -376,6 +385,22 @@ public class MemberMockController {
         public static class MyPostDto {
             private Long postId;
             private String title;
+        }
+        @Getter
+        @Setter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class BookmarkedPostDto {
+            private Long postId;
+            private String title;
+        }
+        @Getter
+        @Setter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class BookmarkedPlaceDto {
+            private Long placeId;
+            private String name;
         }
     }
 
@@ -397,12 +422,31 @@ public class MemberMockController {
             private String email;
             private String name;
             private String profileImage;
-            private int goalAmount;
             private int level;
             private int currentExp;
             private int nextLevelExp;
             private int expProgress;
             private List<MemberMypageRequest.MyPostDto> myPosts;
+            private String goalStuff; // ex) "자동차"
+            private java.math.BigDecimal remainPrice; // ex) 10000
+            private List<BookmarkedPostDto> bookmarkedPosts;
+            private List<BookmarkedPlaceDto> bookmarkedPlaces;
+        }
+        @Getter
+        @Setter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class BookmarkedPostDto {
+            private Long postId;
+            private String title;
+        }
+        @Getter
+        @Setter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class BookmarkedPlaceDto {
+            private Long placeId;
+            private String name;
         }
     }
 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/mock/notification/NotificationMockController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/mock/notification/NotificationMockController.java
@@ -15,7 +15,20 @@ public class NotificationMockController {
     @GetMapping
     public ResponseEntity<NotificationListResponse> getNotifications() {
         NotificationListResponse.Data data = new NotificationListResponse.Data(List.of(
-                Map.of("notificationId", 1, "message", "이번 달 외식비 지출이 많아요!", "read", false)
+                Map.of(
+                    "notificationId", 1,
+                    "message", "이번 달 외식비 지출이 많아요!",
+                    "read", false,
+                    "senderId", 2,
+                    "type", "NOTICE"
+                ),
+                Map.of(
+                    "notificationId", 2,
+                    "message", "안재호님이 회원님의 게시글에 좋아요를 남겼어요!",
+                    "read", false,
+                    "senderId", 3,
+                    "type", "LIKE"
+                )
         ));
         return ResponseEntity.ok(new NotificationListResponse(2000, "알림 목록을 조회했습니다.", data));
     }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/domain/Member.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.grepp.spring.app.model.member.domain;
 
+import com.google.type.Decimal;
 import com.grepp.spring.app.model.attendance.domain.Attendance;
 import com.grepp.spring.app.model.budget.domain.Budget;
 import com.grepp.spring.app.model.challenge_count.domain.ChallengeCount;
@@ -74,6 +75,12 @@ public class Member {
 
     @Column
     private Integer totalExp;
+
+    @Column
+    private Decimal goalAmount;
+
+    @Column
+    private String goalStuff;
 
     @OneToMany(mappedBy = "member")
     private Set<CommunityPost> posts = new HashSet<>();

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/domain/Notification.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/domain/Notification.java
@@ -41,6 +41,12 @@ public class Notification {
     @Column(nullable = false)
     private Boolean isRead;
 
+    @Column(nullable = false)
+    private int senderId; // 보낸이
+
+    @Column(length = 255)
+    private String type; // 알림타입
+
     @Column
     private LocalDateTime createdAt;
 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/model/NotificationDTO.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/model/NotificationDTO.java
@@ -34,4 +34,7 @@ public class NotificationDTO {
     @NotNull
     private Long member;
 
+    private int senderId; // 보낸이
+    private String type; // 알림타입
+
 }


### PR DESCRIPTION
DB/엔티티 변경
 - notification 테이블에 senderId(int, NOT NULL) 필드 추가
 - notification 테이블에 type(varchar(255), NULL 허용) 필드 추가
 - Notification 엔티티와 NotificationDTO에 해당 필드 매핑 추가

API 응답 변경
 - NotificationMockController에서 mock 응답에 senderId, type 필드 포함
 - 예시 데이터에 senderId=2, type="NOTICE" 및 senderId=3, type="LIKE" 추가