### PR TITLE
feat: 이메일 인증 시스템 구현 및 마이페이지 DTO 개선

### DIFF
--- a/apimocking-main/apimocking-boilerplate/pom.xml
+++ b/apimocking-main/apimocking-boilerplate/pom.xml
@@ -113,6 +113,11 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-mail</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-devtools</artifactId>
       <scope>runtime</scope>
       <optional>true</optional>

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/EmailVerificationController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/EmailVerificationController.java
@@ -1,0 +1,101 @@
+package com.grepp.spring.app.controller.api.member;
+
+import com.grepp.spring.app.model.auth.service.EmailVerificationService;
+import com.grepp.spring.infra.response.ApiResponse;
+import com.grepp.spring.infra.response.ResponseCode;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.context.annotation.Profile;
+
+@RestController
+@RequestMapping("/api/members")
+@Profile("!mock")
+public class EmailVerificationController {
+    
+    private final EmailVerificationService emailVerificationService;
+    
+    public EmailVerificationController(EmailVerificationService emailVerificationService) {
+        this.emailVerificationService = emailVerificationService;
+    }
+    
+    // 이메일 인증 코드 발송
+    @PostMapping("/email/send")
+    public ResponseEntity<ApiResponse<EmailSendResponse>> sendEmailCode(@RequestBody @Valid EmailSendRequest request) {
+        try {
+            emailVerificationService.sendVerificationCode(request.getEmail());
+            return ResponseEntity.ok(ApiResponse.success(new EmailSendResponse("이메일 인증 코드가 발송되었습니다.")));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ApiResponse<>(ResponseCode.INTERNAL_SERVER_ERROR.code(), "이메일 발송에 실패했습니다.", null));
+        }
+    }
+    
+    // 이메일 인증 코드 검증
+    @PostMapping("/email/verify")
+    public ResponseEntity<ApiResponse<EmailVerifyResponse>> verifyEmailCode(@RequestBody @Valid EmailVerifyRequest request) {
+        boolean isValid = emailVerificationService.verifyCode(request.getEmail(), request.getCode());
+        
+        if (isValid) {
+            return ResponseEntity.ok(ApiResponse.success(new EmailVerifyResponse("이메일 인증이 완료되었습니다.")));
+        } else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ApiResponse<>(ResponseCode.BAD_REQUEST.code(), "인증 코드가 올바르지 않거나 만료되었습니다.", null));
+        }
+    }
+    
+    // 이메일 인증 상태 확인
+    @GetMapping("/email/status/{email}")
+    public ResponseEntity<ApiResponse<EmailStatusResponse>> checkEmailStatus(@PathVariable String email) {
+        boolean isVerified = emailVerificationService.isEmailVerified(email);
+        return ResponseEntity.ok(ApiResponse.success(new EmailStatusResponse(isVerified)));
+    }
+    
+    // === DTO 클래스들 ===
+    
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EmailSendRequest {
+        private String email;
+    }
+    
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EmailSendResponse {
+        private String message;
+    }
+    
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EmailVerifyRequest {
+        private String email;
+        private String code;
+    }
+    
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EmailVerifyResponse {
+        private String message;
+    }
+    
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EmailStatusResponse {
+        private boolean verified;
+    }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import com.grepp.spring.app.model.auth.AuthService;
 import com.grepp.spring.app.model.auth.dto.TokenDto;
+import com.grepp.spring.app.model.auth.service.EmailVerificationService;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseCookie;
@@ -27,12 +28,14 @@ public class MemberController {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthService authService;
+    private final EmailVerificationService emailVerificationService;
 
-    public MemberController(MemberService memberService, MemberRepository memberRepository, PasswordEncoder passwordEncoder, AuthService authService) {
+    public MemberController(MemberService memberService, MemberRepository memberRepository, PasswordEncoder passwordEncoder, AuthService authService, EmailVerificationService emailVerificationService) {
         this.memberService = memberService;
         this.memberRepository = memberRepository;
         this.passwordEncoder = passwordEncoder;
         this.authService = authService;
+        this.emailVerificationService = emailVerificationService;
     }
 
     // 회원가입
@@ -51,6 +54,13 @@ public class MemberController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(new ApiResponse<>(ResponseCode.BAD_REQUEST.code(), "비밀번호가 일치하지 않습니다.", null));
         }
+        
+        // 이메일 인증 확인
+        if (!emailVerificationService.isEmailVerified(request.getEmail())) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ApiResponse<>(ResponseCode.BAD_REQUEST.code(), "이메일 인증이 필요합니다.", null));
+        }
+        
         // 회원 생성
         Member member = new Member();
         member.setEmail(request.getEmail());

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/mock/member/MemberMockController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/mock/member/MemberMockController.java
@@ -157,10 +157,15 @@ public class MemberMockController {
         MemberMypageRequest.MyPostDto post = new MemberMypageRequest.MyPostDto(1L, "첫 번째 글");
         MemberMypageResponse.BookmarkedPostDto bookmarkedPost = new MemberMypageResponse.BookmarkedPostDto(2L, "나만의 가성비 장소");
         MemberMypageResponse.BookmarkedPlaceDto bookmarkedPlace = new MemberMypageResponse.BookmarkedPlaceDto(1L, "착한식당");
+        MemberMypageResponse.AchievedTitleDto equippedTitle = new MemberMypageResponse.AchievedTitleDto(2L, "절약왕", "한 달 동안 지출을 10만원 이하로!", 1, true);
+        MemberMypageResponse.AchievedTitleDto title1 = new MemberMypageResponse.AchievedTitleDto(1L, "개근왕", "30일 연속 출석", 30, true);
+        MemberMypageResponse.AchievedTitleDto title2 = equippedTitle;
+        MemberMypageResponse.AchievedTitleDto title3 = new MemberMypageResponse.AchievedTitleDto(3L, "인싸왕", "친구 5명 초대", 5, true);
         MemberMypageResponse.Data data = new MemberMypageResponse.Data(
                 1, "test@test.com", "테스트유저", "https://image.url", 5, 1200, 2000, 60, List.of(post),
                 "자동차", new java.math.BigDecimal("10000"),
-                List.of(bookmarkedPost), List.of(bookmarkedPlace)
+                List.of(bookmarkedPost), List.of(bookmarkedPlace),
+                equippedTitle, List.of(title1, title2, title3)
         );
         MemberMypageResponse response = new MemberMypageResponse(2000, "마이페이지 조회 성공", data);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -169,11 +174,16 @@ public class MemberMockController {
     @PatchMapping("/mypage")
     public ResponseEntity<ApiResponse<MemberMypageResponse>> updateMypage(@RequestBody MemberMypageRequest request) {
         // 마이페이지 수정 Mock 응답
+        MemberMypageResponse.AchievedTitleDto equippedTitle = new MemberMypageResponse.AchievedTitleDto(2L, "절약왕", "한 달 동안 지출을 10만원 이하로!", 1, true);
+        MemberMypageResponse.AchievedTitleDto title1 = new MemberMypageResponse.AchievedTitleDto(1L, "개근왕", "30일 연속 출석", 30, true);
+        MemberMypageResponse.AchievedTitleDto title2 = equippedTitle;
+        MemberMypageResponse.AchievedTitleDto title3 = new MemberMypageResponse.AchievedTitleDto(3L, "인싸왕", "친구 5명 초대", 5, true);
         MemberMypageResponse.Data data = new MemberMypageResponse.Data(
-                1,"test@test.com", request.getName(), request.getProfileImage(),
+                1, "test@test.com", request.getName(), request.getProfileImage(),
                 request.getLevel(), request.getCurrentExp(), request.getNextLevelExp(), request.getExpProgress(), request.getMyPosts(),
                 request.getGoalStuff(), request.getRemainPrice(),
-                request.getBookmarkedPosts(), request.getBookmarkedPlaces()
+                request.getBookmarkedPosts(), request.getBookmarkedPlaces(),
+                equippedTitle, List.of(title1, title2, title3)
         );
         MemberMypageResponse response = new MemberMypageResponse(2000, "마이페이지 수정 성공", data);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -431,6 +441,8 @@ public class MemberMockController {
             private java.math.BigDecimal remainPrice; // ex) 10000
             private List<BookmarkedPostDto> bookmarkedPosts;
             private List<BookmarkedPlaceDto> bookmarkedPlaces;
+            private AchievedTitleDto equippedTitle; // 장착 칭호
+            private List<AchievedTitleDto> achievedTitles; // 달성 칭호 목록
         }
         @Getter
         @Setter
@@ -447,6 +459,17 @@ public class MemberMockController {
         public static class BookmarkedPlaceDto {
             private Long placeId;
             private String name;
+        }
+        @Getter
+        @Setter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class AchievedTitleDto {
+            private Long titleId;
+            private String name;
+            private String description;
+            private Integer minCount;
+            private Boolean achieved;
         }
     }
 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/auth/domain/EmailVerification.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/auth/domain/EmailVerification.java
@@ -1,0 +1,65 @@
+package com.grepp.spring.app.model.auth.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "email_verification")
+public class EmailVerification {
+    
+    @Id
+    @Column(nullable = false, updatable = false)
+    @SequenceGenerator(
+            name = "primary_sequence",
+            sequenceName = "primary_sequence",
+            allocationSize = 1,
+            initialValue = 10000
+    )
+    @GeneratedValue(
+            strategy = GenerationType.SEQUENCE,
+            generator = "primary_sequence"
+    )
+    private Long emailVerificationId;
+    
+    @Column(nullable = false, unique = true)
+    private String email;
+    
+    @Column(nullable = false)
+    private String verificationCode;
+    
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+    
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+    
+    @Column(nullable = false)
+    private boolean verified = false;
+    
+    // 인증 코드 만료 시간 (10분)
+    private static final int EXPIRATION_MINUTES = 10;
+    
+    public EmailVerification(String email, String verificationCode) {
+        this.email = email;
+        this.verificationCode = verificationCode;
+        this.createdAt = LocalDateTime.now();
+        this.expiresAt = LocalDateTime.now().plusMinutes(EXPIRATION_MINUTES);
+        this.verified = false;
+    }
+    
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiresAt);
+    }
+    
+    public void markAsVerified() {
+        this.verified = true;
+    }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/auth/repos/EmailVerificationRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/auth/repos/EmailVerificationRepository.java
@@ -1,0 +1,25 @@
+package com.grepp.spring.app.model.auth.repos;
+
+import com.grepp.spring.app.model.auth.domain.EmailVerification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import java.util.Optional;
+
+@Repository
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+    
+    Optional<EmailVerification> findByEmailAndVerificationCode(String email, String verificationCode);
+    
+    Optional<EmailVerification> findByEmail(String email);
+    
+    @Modifying
+    @Query("DELETE FROM EmailVerification e WHERE e.email = :email")
+    void deleteByEmail(@Param("email") String email);
+    
+    @Modifying
+    @Query("DELETE FROM EmailVerification e WHERE e.expiresAt < CURRENT_TIMESTAMP")
+    void deleteExpiredVerifications();
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/auth/service/EmailCleanupScheduler.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/auth/service/EmailCleanupScheduler.java
@@ -1,0 +1,22 @@
+package com.grepp.spring.app.model.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class EmailCleanupScheduler {
+    
+    private final EmailVerificationService emailVerificationService;
+    
+    // 매시간 실행하여 만료된 인증 코드 정리
+    @Scheduled(fixedRate = 3600000) // 1시간 = 3600000ms
+    public void cleanupExpiredVerifications() {
+        log.info("만료된 이메일 인증 코드 정리 시작");
+        emailVerificationService.cleanupExpiredVerifications();
+        log.info("만료된 이메일 인증 코드 정리 완료");
+    }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/auth/service/EmailService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/auth/service/EmailService.java
@@ -1,0 +1,61 @@
+package com.grepp.spring.app.model.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailService {
+    
+    private final JavaMailSender mailSender;
+    
+    public void sendVerificationEmail(String to, String verificationCode) {
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(to);
+            message.setSubject("[가계부 앱] 이메일 인증 코드");
+            message.setText(String.format(
+                "안녕하세요!\n\n" +
+                "가계부 앱 회원가입을 위한 이메일 인증 코드입니다.\n\n" +
+                "인증 코드: %s\n\n" +
+                "이 코드는 10분 후에 만료됩니다.\n" +
+                "본인이 요청하지 않은 경우 이 메일을 무시하세요.\n\n" +
+                "감사합니다.",
+                verificationCode
+            ));
+            
+            mailSender.send(message);
+            log.info("인증 이메일 발송 완료: {}", to);
+        } catch (Exception e) {
+            log.error("인증 이메일 발송 실패: {}", to, e);
+            throw new RuntimeException("이메일 발송에 실패했습니다.", e);
+        }
+    }
+    
+    public void sendPasswordResetEmail(String to, String resetCode) {
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(to);
+            message.setSubject("[가계부 앱] 비밀번호 재설정");
+            message.setText(String.format(
+                "안녕하세요!\n\n" +
+                "비밀번호 재설정을 위한 인증 코드입니다.\n\n" +
+                "인증 코드: %s\n\n" +
+                "이 코드는 10분 후에 만료됩니다.\n" +
+                "본인이 요청하지 않은 경우 이 메일을 무시하세요.\n\n" +
+                "감사합니다.",
+                resetCode
+            ));
+            
+            mailSender.send(message);
+            log.info("비밀번호 재설정 이메일 발송 완료: {}", to);
+        } catch (Exception e) {
+            log.error("비밀번호 재설정 이메일 발송 실패: {}", to, e);
+            throw new RuntimeException("이메일 발송에 실패했습니다.", e);
+        }
+    }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/auth/service/EmailVerificationService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/auth/service/EmailVerificationService.java
@@ -1,0 +1,87 @@
+package com.grepp.spring.app.model.auth.service;
+
+import com.grepp.spring.app.model.auth.domain.EmailVerification;
+import com.grepp.spring.app.model.auth.repos.EmailVerificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class EmailVerificationService {
+    
+    private final EmailVerificationRepository emailVerificationRepository;
+    private final EmailService emailService;
+    
+    // 6자리 숫자 인증 코드 생성
+    public String generateVerificationCode() {
+        Random random = new Random();
+        return String.format("%06d", random.nextInt(1000000));
+    }
+    
+    // 인증 코드 발송
+    public void sendVerificationCode(String email) {
+        // 기존 인증 코드가 있다면 삭제
+        emailVerificationRepository.deleteByEmail(email);
+        
+        // 새로운 인증 코드 생성
+        String verificationCode = generateVerificationCode();
+        
+        // 인증 코드 저장
+        EmailVerification emailVerification = new EmailVerification(email, verificationCode);
+        emailVerificationRepository.save(emailVerification);
+        
+        // 이메일 발송
+        emailService.sendVerificationEmail(email, verificationCode);
+        
+        log.info("인증 코드 발송 완료: {}", email);
+    }
+    
+    // 인증 코드 검증
+    public boolean verifyCode(String email, String code) {
+        EmailVerification verification = emailVerificationRepository
+            .findByEmailAndVerificationCode(email, code)
+            .orElse(null);
+        
+        if (verification == null) {
+            log.warn("인증 코드 불일치: {}", email);
+            return false;
+        }
+        
+        if (verification.isExpired()) {
+            log.warn("만료된 인증 코드: {}", email);
+            emailVerificationRepository.delete(verification);
+            return false;
+        }
+        
+        if (verification.isVerified()) {
+            log.warn("이미 인증된 코드: {}", email);
+            return false;
+        }
+        
+        // 인증 완료 처리
+        verification.markAsVerified();
+        emailVerificationRepository.save(verification);
+        
+        log.info("이메일 인증 완료: {}", email);
+        return true;
+    }
+    
+    // 인증 완료 여부 확인
+    public boolean isEmailVerified(String email) {
+        return emailVerificationRepository.findByEmail(email)
+            .map(EmailVerification::isVerified)
+            .orElse(false);
+    }
+    
+    // 만료된 인증 코드 정리 (스케줄러에서 호출)
+    @Transactional
+    public void cleanupExpiredVerifications() {
+        emailVerificationRepository.deleteExpiredVerifications();
+        log.info("만료된 인증 코드 정리 완료");
+    }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/domain/Member.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/domain/Member.java
@@ -7,13 +7,17 @@ import com.grepp.spring.app.model.challenge_count.domain.ChallengeCount;
 import com.grepp.spring.app.model.community_post.domain.CommunityPost;
 import com.grepp.spring.app.model.notification.domain.Notification;
 import com.grepp.spring.app.model.place_bookmark.domain.PlaceBookmark;
+import com.grepp.spring.app.model.achieved_title.domain.AchievedTitle;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
@@ -81,6 +85,10 @@ public class Member {
 
     @Column
     private String goalStuff;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "equipped_title_id")
+    private AchievedTitle equippedTitle; // 장착(대표) 칭호
 
     @OneToMany(mappedBy = "member")
     private Set<CommunityPost> posts = new HashSet<>();

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -39,6 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         List<String> excludePath = new ArrayList<>();
         excludePath.addAll(List.of("/auth/signup", "/auth/login",  "/favicon.ico", "/img", "/js","/css","/download"));
         excludePath.addAll(List.of("/error", "/api/member/exists", "/member/signin", "/member/signup"));
+        excludePath.addAll(List.of("/api/members/email/send", "/api/members/email/verify", "/api/members/email/status"));
         String path = request.getRequestURI();
         return excludePath.stream().anyMatch(path::startsWith);
     }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
                 (requests) -> requests
                                   .requestMatchers("/favicon.ico", "/img/**", "/js/**","/css/**").permitAll()
                                   .requestMatchers("/", "/error", "/auth/login", "/auth/signup").permitAll()
-                                  .requestMatchers("/api/members/login", "/api/members/signup").permitAll()
+                                  .requestMatchers("/api/members/login", "/api/members/signup", "/api/members/email/**").permitAll()
                                   .requestMatchers("/api/**").authenticated()
                                   .anyRequest().permitAll()
             )


### PR DESCRIPTION
## 📋 변경 사항

### 이메일 인증 시스템 구현
- **EmailVerification 엔티티**: 이메일 인증 코드 저장 및 관리
- **EmailService**: Gmail SMTP를 통한 실제 이메일 발송
- **EmailVerificationService**: 인증 코드 생성, 검증, 만료 관리
- **EmailVerificationController**: 이메일 인증 관련 API 엔드포인트

### 추가된 API
- `POST /api/members/email/send` - 인증 코드 발송
- `POST /api/members/email/verify` - 인증 코드 검증  
- `GET /api/members/email/status/{email}` - 인증 상태 확인

### 회원가입 보안 강화
- **Member 엔티티**: `equippedTitle` 필드 추가 (장착 칭호)
- **회원가입 로직**: 이메일 인증 완료 필수화
- **MemberController**: 인증 상태 확인 후 회원 생성

### 환경별 설정
- **Local/Production**: Gmail SMTP 설정 적용

## 🔧 기술적 변경사항
- Spring Boot Mail Starter 의존성 추가
- Jakarta Mail API 연동
- 이메일 인증 코드 6자리 숫자 생성
- 10분 만료 시간 설정
- 스케줄러를 통한 만료 코드 자동 정리

## �� 이메일 설정
- **Gmail 계정**: ethanahn00@gmail.com
- **SMTP 서버**: smtp.gmail.com:587
- **보안**: 앱 비밀번호 사용

## �� 참고사항
- 이메일 인증은 회원가입 전 필수 단계
- 인증 코드는 10분 후 자동 만료
- 만료된 코드는 매시간 자동 정리