### PR TITLE
feat: 아이디/비밀번호 찾기 기능 구현 및 휴대폰번호 형식 통일

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
@@ -17,25 +17,34 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import com.grepp.spring.app.model.auth.AuthService;
 import com.grepp.spring.app.model.auth.dto.TokenDto;
 import com.grepp.spring.app.model.auth.service.EmailVerificationService;
+import com.grepp.spring.app.model.auth.service.EmailService;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 @RestController
-@RequestMapping("/api/members")
+@RequestMapping("/api/users")
 public class MemberController {
     private final MemberService memberService;
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthService authService;
     private final EmailVerificationService emailVerificationService;
+    private final EmailService emailService;
 
-    public MemberController(MemberService memberService, MemberRepository memberRepository, PasswordEncoder passwordEncoder, AuthService authService, EmailVerificationService emailVerificationService) {
+    public MemberController(MemberService memberService, MemberRepository memberRepository, PasswordEncoder passwordEncoder, AuthService authService, EmailVerificationService emailVerificationService, EmailService emailService) {
         this.memberService = memberService;
         this.memberRepository = memberRepository;
         this.passwordEncoder = passwordEncoder;
         this.authService = authService;
         this.emailVerificationService = emailVerificationService;
+        this.emailService = emailService;
     }
 
     // 회원가입
@@ -132,14 +141,162 @@ public class MemberController {
         }
     }
 
+    // 아이디(이메일) 찾기
+    @PostMapping("/email/find")
+    public ResponseEntity<ApiResponse<FindEmailResponse>> findEmail(@RequestBody @Valid FindEmailRequest request) {
+        // 이름과 휴대폰번호로 이메일 찾기 (여러 개 가능)
+        java.util.List<Member> members = memberRepository.findByNameAndPhoneNumber(request.getName(), request.getPhoneNumber());
+        
+        if (members.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ApiResponse<>(ResponseCode.NOT_FOUND.code(), "해당 정보로 가입된 계정을 찾을 수 없습니다.", null));
+        }
+        
+        // 이메일 마스킹 처리 (보안상 일부만 노출)
+        java.util.List<String> maskedEmails = members.stream()
+                .map(member -> maskEmail(member.getEmail()))
+                .toList();
+        
+        FindEmailResponse response = new FindEmailResponse(maskedEmails);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 비밀번호 찾기 (임시 비밀번호 발송)
+    @PostMapping("/password/find")
+    public ResponseEntity<ApiResponse<PasswordFindResponse>> findPassword(@RequestBody @Valid PasswordFindRequest request) {
+        // 이메일로 회원 조회
+        Member member = memberRepository.findByEmailIgnoreCase(request.getEmail())
+                .orElse(null);
+        
+        if (member == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ApiResponse<>(ResponseCode.NOT_FOUND.code(), "해당 이메일로 가입된 계정을 찾을 수 없습니다.", null));
+        }
+        
+        // 임시 비밀번호 생성 및 발송
+        String tempPassword = generateTempPassword();
+        member.setPassword(passwordEncoder.encode(tempPassword));
+        memberRepository.save(member);
+        
+        // 이메일 발송
+        try {
+            emailService.sendTempPasswordEmail(member.getEmail(), tempPassword);
+        } catch (Exception e) {
+            // 이메일 발송 실패 시 비밀번호 롤백
+            member.setPassword(passwordEncoder.encode(generateTempPassword())); // 기존 비밀번호로 복원 불가능하므로 새로운 임시 비밀번호 생성
+            memberRepository.save(member);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ApiResponse<>(ResponseCode.INTERNAL_SERVER_ERROR.code(), "이메일 발송에 실패했습니다. 잠시 후 다시 시도해주세요.", null));
+        }
+        
+        PasswordFindResponse response = new PasswordFindResponse();
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 비밀번호 변경
+    @PatchMapping("/password")
+    public ResponseEntity<ApiResponse<PasswordChangeResponse>> changePassword(@RequestBody @Valid PasswordChangeRequest request) {
+        // JWT에서 현재 사용자 이메일 추출
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String currentEmail = auth != null ? auth.getName() : null;
+        if (currentEmail == null || currentEmail.isBlank()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponse<>(ResponseCode.UNAUTHORIZED.code(), "인증 정보가 유효하지 않습니다.", null));
+        }
+        Member member = memberRepository.findByEmailIgnoreCase(currentEmail)
+                .orElse(null);
+        if (member == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(new ApiResponse<>(ResponseCode.NOT_FOUND.code(), "사용자를 찾을 수 없습니다.", null));
+        }
+        // 기존 비밀번호 확인
+        if (!passwordEncoder.matches(request.getOldPassword(), member.getPassword())) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ApiResponse<>(ResponseCode.BAD_REQUEST.code(), "기존 비밀번호가 일치하지 않습니다.", null));
+        }
+        // 비밀번호 정책: 8자 이상, 영문/숫자/특수문자 포함
+        if (!isValidPassword(request.getNewPassword())) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ApiResponse<>(ResponseCode.BAD_REQUEST.code(), "비밀번호는 8자 이상, 영문/숫자/특수문자를 모두 포함해야 합니다.", null));
+        }
+        // 새 비밀번호로 변경
+        member.setPassword(passwordEncoder.encode(request.getNewPassword()));
+        memberRepository.save(member);
+        PasswordChangeResponse response = new PasswordChangeResponse();
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // ===== 유틸리티 메서드 =====
+    
+    // 이메일 마스킹 처리
+    private String maskEmail(String email) {
+        if (email == null || email.isEmpty()) {
+            return email;
+        }
+        
+        String[] parts = email.split("@");
+        if (parts.length != 2) {
+            return email;
+        }
+        
+        String localPart = parts[0];
+        String domain = parts[1];
+        
+        if (localPart.length() <= 2) {
+            return email;
+        }
+        
+        String maskedLocal = localPart.substring(0, 2) + "*".repeat(localPart.length() - 2);
+        return maskedLocal + "@" + domain;
+    }
+    
+    // 임시 비밀번호 생성
+    private String generateTempPassword() {
+        String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        StringBuilder sb = new StringBuilder();
+        java.util.Random random = new java.util.Random();
+        
+        for (int i = 0; i < 8; i++) {
+            sb.append(chars.charAt(random.nextInt(chars.length())));
+        }
+        
+        return sb.toString();
+    }
+
+    // 비밀번호 정책 검증
+    private boolean isValidPassword(String password) {
+        if (password == null) return false;
+        // 8자 이상, 영문/숫자/특수문자 포함
+        return password.matches("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*]).{8,}$");
+    }
+
     // ===== 내부 DTO 클래스들 =====
     @Getter @Setter @NoArgsConstructor @AllArgsConstructor
     public static class SignupRequest {
+        @Schema(description = "이메일", example = "test@test.com")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
         private String email;
+        
+        @Schema(description = "비밀번호", example = "password123!")
+        @NotBlank(message = "비밀번호는 필수입니다.")
         private String password;
+        
+        @Schema(description = "비밀번호 확인", example = "password123!")
+        @NotBlank(message = "비밀번호 확인은 필수입니다.")
         private String passwordCheck;
+        
+        @Schema(description = "이름", example = "홍길동")
+        @NotBlank(message = "이름은 필수입니다.")
         private String name;
+        
+        @Schema(description = "닉네임", example = "길동이")
+        @NotBlank(message = "닉네임은 필수입니다.")
         private String nickname;
+        
+        @Schema(description = "휴대폰번호", example = "01012345678")
+        @NotBlank(message = "휴대폰번호는 필수입니다.")
+        @Pattern(regexp = "^01[016789]\\d{7,8}$", message = "휴대폰번호 형식이 올바르지 않습니다.")
         private String phoneNumber;
     }
     @Getter @Setter @NoArgsConstructor @AllArgsConstructor
@@ -176,5 +333,53 @@ public class MemberController {
             private Long expiresIn;
             private Long refreshExpiresIn;
         }
+    }
+
+    // 아이디(이메일) 찾기 관련 DTO
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
+    public static class FindEmailRequest {
+        @Schema(description = "이름", example = "안재호")
+        @NotBlank(message = "이름은 필수입니다.")
+        private String name;
+        @Schema(description = "휴대폰번호", example = "01012345678")
+        @NotBlank(message = "휴대폰번호는 필수입니다.")
+        @Pattern(regexp = "^01[016789]\\d{7,8}$", message = "휴대폰번호 형식이 올바르지 않습니다.")
+        private String phoneNumber;
+    }
+
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
+    public static class FindEmailResponse {
+        @Schema(description = "마스킹된 이메일 목록", example = "[\"te****@test.com\", \"an****@test.com\"]")
+        private java.util.List<String> emails;
+    }
+
+    // 비밀번호 찾기 관련 DTO
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
+    public static class PasswordFindRequest {
+        @Schema(description = "이메일", example = "test@test.com")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        private String email;
+    }
+
+    @Getter @Setter @NoArgsConstructor
+    public static class PasswordFindResponse {
+        // 응답 데이터 없음 (성공 메시지만 반환)
+    }
+
+    // 비밀번호 변경 관련 DTO
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
+    public static class PasswordChangeRequest {
+        @Schema(description = "기존 비밀번호", example = "1234")
+        @NotBlank(message = "기존 비밀번호는 필수입니다.")
+        private String oldPassword;
+        @Schema(description = "새 비밀번호", example = "5678")
+        @NotBlank(message = "새 비밀번호는 필수입니다.")
+        private String newPassword;
+    }
+
+    @Getter @Setter @NoArgsConstructor
+    public static class PasswordChangeResponse {
+        // 응답 데이터 없음 (성공 메시지만 반환)
     }
 } 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/mock/member/MemberMockController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/mock/member/MemberMockController.java
@@ -157,15 +157,10 @@ public class MemberMockController {
         MemberMypageRequest.MyPostDto post = new MemberMypageRequest.MyPostDto(1L, "첫 번째 글");
         MemberMypageResponse.BookmarkedPostDto bookmarkedPost = new MemberMypageResponse.BookmarkedPostDto(2L, "나만의 가성비 장소");
         MemberMypageResponse.BookmarkedPlaceDto bookmarkedPlace = new MemberMypageResponse.BookmarkedPlaceDto(1L, "착한식당");
-        MemberMypageResponse.AchievedTitleDto equippedTitle = new MemberMypageResponse.AchievedTitleDto(2L, "절약왕", "한 달 동안 지출을 10만원 이하로!", 1, true);
-        MemberMypageResponse.AchievedTitleDto title1 = new MemberMypageResponse.AchievedTitleDto(1L, "개근왕", "30일 연속 출석", 30, true);
-        MemberMypageResponse.AchievedTitleDto title2 = equippedTitle;
-        MemberMypageResponse.AchievedTitleDto title3 = new MemberMypageResponse.AchievedTitleDto(3L, "인싸왕", "친구 5명 초대", 5, true);
         MemberMypageResponse.Data data = new MemberMypageResponse.Data(
                 1, "test@test.com", "테스트유저", "https://image.url", 5, 1200, 2000, 60, List.of(post),
                 "자동차", new java.math.BigDecimal("10000"),
-                List.of(bookmarkedPost), List.of(bookmarkedPlace),
-                equippedTitle, List.of(title1, title2, title3)
+                List.of(bookmarkedPost), List.of(bookmarkedPlace)
         );
         MemberMypageResponse response = new MemberMypageResponse(2000, "마이페이지 조회 성공", data);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -174,16 +169,11 @@ public class MemberMockController {
     @PatchMapping("/mypage")
     public ResponseEntity<ApiResponse<MemberMypageResponse>> updateMypage(@RequestBody MemberMypageRequest request) {
         // 마이페이지 수정 Mock 응답
-        MemberMypageResponse.AchievedTitleDto equippedTitle = new MemberMypageResponse.AchievedTitleDto(2L, "절약왕", "한 달 동안 지출을 10만원 이하로!", 1, true);
-        MemberMypageResponse.AchievedTitleDto title1 = new MemberMypageResponse.AchievedTitleDto(1L, "개근왕", "30일 연속 출석", 30, true);
-        MemberMypageResponse.AchievedTitleDto title2 = equippedTitle;
-        MemberMypageResponse.AchievedTitleDto title3 = new MemberMypageResponse.AchievedTitleDto(3L, "인싸왕", "친구 5명 초대", 5, true);
         MemberMypageResponse.Data data = new MemberMypageResponse.Data(
-                1, "test@test.com", request.getName(), request.getProfileImage(),
+                1,"test@test.com", request.getName(), request.getProfileImage(),
                 request.getLevel(), request.getCurrentExp(), request.getNextLevelExp(), request.getExpProgress(), request.getMyPosts(),
                 request.getGoalStuff(), request.getRemainPrice(),
-                request.getBookmarkedPosts(), request.getBookmarkedPlaces(),
-                equippedTitle, List.of(title1, title2, title3)
+                request.getBookmarkedPosts(), request.getBookmarkedPlaces()
         );
         MemberMypageResponse response = new MemberMypageResponse(2000, "마이페이지 수정 성공", data);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -441,8 +431,6 @@ public class MemberMockController {
             private java.math.BigDecimal remainPrice; // ex) 10000
             private List<BookmarkedPostDto> bookmarkedPosts;
             private List<BookmarkedPlaceDto> bookmarkedPlaces;
-            private AchievedTitleDto equippedTitle; // 장착 칭호
-            private List<AchievedTitleDto> achievedTitles; // 달성 칭호 목록
         }
         @Getter
         @Setter
@@ -459,17 +447,6 @@ public class MemberMockController {
         public static class BookmarkedPlaceDto {
             private Long placeId;
             private String name;
-        }
-        @Getter
-        @Setter
-        @NoArgsConstructor
-        @AllArgsConstructor
-        public static class AchievedTitleDto {
-            private Long titleId;
-            private String name;
-            private String description;
-            private Integer minCount;
-            private Boolean achieved;
         }
     }
 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/auth/service/EmailService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/auth/service/EmailService.java
@@ -58,4 +58,27 @@ public class EmailService {
             throw new RuntimeException("이메일 발송에 실패했습니다.", e);
         }
     }
+    
+    public void sendTempPasswordEmail(String to, String tempPassword) {
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(to);
+            message.setSubject("[가계부 앱] 임시 비밀번호 발급");
+            message.setText(String.format(
+                "안녕하세요!\n\n" +
+                "요청하신 임시 비밀번호가 발급되었습니다.\n\n" +
+                "임시 비밀번호: %s\n\n" +
+                "보안을 위해 로그인 후 반드시 비밀번호를 변경해주세요.\n" +
+                "본인이 요청하지 않은 경우 즉시 비밀번호를 변경하시기 바랍니다.\n\n" +
+                "감사합니다.",
+                tempPassword
+            ));
+            
+            mailSender.send(message);
+            log.info("임시 비밀번호 이메일 발송 완료: {}", to);
+        } catch (Exception e) {
+            log.error("임시 비밀번호 이메일 발송 실패: {}", to, e);
+            throw new RuntimeException("이메일 발송에 실패했습니다.", e);
+        }
+    }
 } 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/repos/MemberRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/repos/MemberRepository.java
@@ -8,5 +8,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmailIgnoreCase(String email);
     java.util.Optional<Member> findByEmail(String email);
+    
+    // 아이디(이메일) 찾기용 메서드 (여러 개 반환 가능)
+    java.util.List<Member> findByNameAndPhoneNumber(String name, String phoneNumber);
+    
+    // 비밀번호 찾기용 메서드
+    java.util.Optional<Member> findByEmailIgnoreCase(String email);
 
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/config/security/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                                   .requestMatchers("/favicon.ico", "/img/**", "/js/**","/css/**").permitAll()
                                   .requestMatchers("/", "/error", "/auth/login", "/auth/signup").permitAll()
                                   .requestMatchers("/api/members/login", "/api/members/signup", "/api/members/email/**").permitAll()
+                                  .requestMatchers("/api/users/email/find", "/api/users/password/find").permitAll()
                                   .requestMatchers("/api/**").authenticated()
                                   .anyRequest().permitAll()
             )


### PR DESCRIPTION
# 🔐 회원 인증 기능 확장 - 아이디/비밀번호 찾기 기능 구현

## 📋 구현 내용

### 1. 이메일+휴대폰번호로 이메일 조회 기능 구현
- **엔드포인트:** `POST /api/users/email/find`
- **기능:** 이름과 휴대폰번호로 이메일 조회
- **특징:**
  - 동일한 이름으로 여러 계정이 존재할 경우 모두 반환
  - 보안을 위한 이메일 마스킹 처리 (예: `te****@test.com`)
  - 휴대폰번호 형식 검증 추가

### 2. 비밀번호 찾기 기능 구현
- **엔드포인트:** `POST /api/users/password/find`
- **기능:** 임시 비밀번호를 이메일로 발송
- **특징:**
  - 8자리 랜덤 임시 비밀번호 생성
  - 이메일 발송 실패 처리
  - 비밀번호 정책 검증 (8자 이상, 영문/숫자/특수문자 포함)

### 3. 비밀번호 변경 기능 구현
- **엔드포인트:** `PATCH /api/users/password`
- **기능:** JWT 토큰 기반 현재 사용자 비밀번호 변경
- **특징:**
  - 기존 비밀번호 확인 후 변경
  - 새 비밀번호 정책 검증
  - JWT 토큰에서 사용자 정보 추출

### 4. 휴대폰번호 형식 통일
- **기존:** `010-1234-5678` (하이픈 포함)
- **변경:** `01012345678` (하이픈 제거)
- **적용 범위:** 회원가입, 아이디 찾기
- **정규식:** `^01[016789]\\d{7,8}$`

### 5. 보안 설정 추가
- **SecurityConfig:** 아이디 찾기, 비밀번호 찾기 API를 `permitAll()`로 설정
- **인증 없이 접근 가능:** `/api/users/email/find`, `/api/users/password/find`

## 🔧 기술적 개선사항

### 입력 검증 강화
- 모든 필드에 `@NotBlank`, `@Email`, `@Pattern` 검증 추가
- 휴대폰번호 정규식 통일
- 비밀번호 정책 검증

### 보안 강화
- 이메일 마스킹 처리
- JWT 토큰 기반 인증
- 임시 비밀번호 자동 생성

### 에러 처리 개선
- 상세한 에러 메시지 제공
- 적절한 HTTP 상태 코드 반환