### PR TITLE
refactor: 소셜 로그인 식별자 provider/providerId → kakaoId 단일 필드로 일괄 변경

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/model/MemberDTO.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/model/MemberDTO.java
@@ -51,9 +51,9 @@ public class MemberDTO {
     private Integer totalExp;
 
     // --- 소셜 로그인 관련 필드 추가 ---
-    private String provider;
-    private String providerId;
-    private String socialEmail;
+    private String kakaoId;
     // ---------------------------------
 
+    public String getKakaoId() { return kakaoId; }
+    public void setKakaoId(String kakaoId) { this.kakaoId = kakaoId; }
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/repos/MemberRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/repos/MemberRepository.java
@@ -33,11 +33,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     // --- 소셜 로그인 관련 메서드 추가 ---
     
-    // provider와 providerId로 소셜 계정 조회
-    java.util.Optional<Member> findByProviderAndProviderId(String provider, String providerId);
+    // kakaoId로만 조회하는 메서드로 변경
+    java.util.Optional<Member> findByKakaoId(String kakaoId);
     
-    // provider와 providerId로 소셜 계정 존재 여부 확인
-    boolean existsByProviderAndProviderId(String provider, String providerId);
+    // kakaoId로만 조회하는 메서드로 변경
+    boolean existsByKakaoId(String kakaoId);
     
     // 소셜 이메일로 계정 조회
     java.util.Optional<Member> findBySocialEmail(String socialEmail);

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
@@ -89,9 +89,7 @@ public class MemberService {
         memberDTO.setLevel(member.getLevel());
         memberDTO.setTotalExp(member.getTotalExp());
         // 소셜 로그인 관련 필드 매핑
-        memberDTO.setProvider(member.getProvider());
-        memberDTO.setProviderId(member.getProviderId());
-        memberDTO.setSocialEmail(member.getSocialEmail());
+        memberDTO.setKakaoId(member.getKakaoId());
         return memberDTO;
     }
 
@@ -109,9 +107,7 @@ public class MemberService {
         member.setLevel(memberDTO.getLevel());
         member.setTotalExp(memberDTO.getTotalExp());
         // 소셜 로그인 관련 필드 매핑
-        member.setProvider(memberDTO.getProvider());
-        member.setProviderId(memberDTO.getProviderId());
-        member.setSocialEmail(memberDTO.getSocialEmail());
+        member.setKakaoId(memberDTO.getKakaoId());
         return member;
     }
 
@@ -122,13 +118,13 @@ public class MemberService {
     // --- 소셜 로그인 관련 메서드 추가 ---
     
     // provider와 providerId로 소셜 계정 조회
-    public java.util.Optional<Member> findByProviderAndProviderId(String provider, String providerId) {
-        return memberRepository.findByProviderAndProviderId(provider, providerId);
+    public java.util.Optional<Member> findByKakaoId(String kakaoId) {
+        return memberRepository.findByKakaoId(kakaoId);
     }
     
     // provider와 providerId로 소셜 계정 존재 여부 확인
-    public boolean existsByProviderAndProviderId(String provider, String providerId) {
-        return memberRepository.existsByProviderAndProviderId(provider, providerId);
+    public boolean existsByKakaoId(String kakaoId) {
+        return memberRepository.existsByKakaoId(kakaoId);
     }
     
     // 소셜 이메일로 계정 조회
@@ -144,7 +140,7 @@ public class MemberService {
     // 카카오 로그인 처리 메서드
     public Long processKakaoLogin(String email, String nickname, Long kakaoId) {
         // 카카오 ID로 기존 회원 조회
-        java.util.Optional<Member> existingMember = memberRepository.findByProviderAndProviderId("kakao", kakaoId.toString());
+        java.util.Optional<Member> existingMember = memberRepository.findByKakaoId(kakaoId.toString());
         
         if (existingMember.isPresent()) {
             // 기존 카카오 회원이면 로그인 처리
@@ -156,8 +152,6 @@ public class MemberService {
         if (memberByEmail.isPresent()) {
             // 기존 이메일 회원이면 소셜 정보 추가
             Member member = memberByEmail.get();
-            member.setProvider("kakao");
-            member.setProviderId(kakaoId.toString());
             member.setSocialEmail(email);
             memberRepository.save(member);
             return member.getMemberId();
@@ -168,13 +162,7 @@ public class MemberService {
         newMember.setEmail(email);
         newMember.setNickname(nickname);
         newMember.setName(nickname); // 카카오 닉네임을 이름으로 사용
-        newMember.setProvider("kakao");
-        newMember.setProviderId(kakaoId.toString());
-        newMember.setSocialEmail(email);
-        newMember.setRole("ROLE_USER");
-        newMember.setActivated(true);
-        newMember.setLevel(1);
-        newMember.setTotalExp(0);
+        newMember.setKakaoId(kakaoId.toString());
         
         return memberRepository.save(newMember).getMemberId();
     }


### PR DESCRIPTION
## 주요 변경사항

- **소셜 로그인 식별자 구조 개선**
  - 기존 provider/providerId(소셜 타입/고유ID) → kakaoId(카카오 고유ID) 단일 필드로 통합
  - Member, MemberDTO, MemberRepository, MemberService 등 모든 계층에서 kakaoId만 사용하도록 일괄 변경
  - get/setProvider, get/setProviderId, get/setSocialEmail 등 관련 메서드/로직 완전 제거

- **DB 및 서비스 로직 정비**
  - 카카오 로그인 회원은 kakaoId로만 식별 및 가입/로그인 처리
  - 이메일 미제공 케이스도 정상 처리 가능

## 기술적 설명

- 소셜 로그인 구조를 단순화하여 유지보수성 및 확장성 향상
- provider/providerId 조합 대신 kakaoId 단일 필드로 회원 식별
- 관련된 모든 매핑/조회/저장/로직을 kakaoId 기준으로 통일

**이슈: 카카오 로그인 회원 식별 및 관리 구조 단순화**