### PR TITLE
Feature/community

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/community/CommunityController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/community/CommunityController.java
@@ -85,7 +85,7 @@ public class CommunityController {
     }
 
     @PostMapping("/posts")
-    @Operation(summary = "커뮤니티 게시글 생성")
+    @Operation(summary = "커뮤니티 게시글 생성", description = "카테고리 : MY_STORE, CHALLENGE, FREE<br/> 챌린지 카테고리 : NO_MONEY, KIND_CONSUMER, DETECTIVE, MASTER,COOK_KING ")
     public ResponseEntity<ApiResponse<Map<String, String>>> createPost(
         @RequestBody @Valid CommunityPostCreateRequest request,
         @AuthenticationPrincipal Principal principal
@@ -197,26 +197,23 @@ public class CommunityController {
             .body(ApiResponse.success(response));
     }
 
-//    @PatchMapping("/posts/{post-id}/like")
-//    @Operation(summary = "커뮤니티 게시글 좋아요 활성화/비활성화", description = "현재는 '좋아요가 등록되었습니다'만 뜹니다")
-//    public ResponseEntity<ApiResponse<Map<String, String>>> toggleLike(
-//        @PathVariable("post-id") int id
-//    ) {
-//
-//        if (id < 0 || id > 4) {
-//            return ResponseEntity
-//                .status(ResponseCode.NOT_FOUND.status())
-//                .body(ApiResponse.error(ResponseCode.NOT_FOUND));
-//        }
-//
-//        Map<String, String> response = new HashMap<>();
-//        response.put("message", "좋아요가 등록되었습니다.");
-//
-//        return ResponseEntity
-//            .status(ResponseCode.OK.status())
-//            .body(ApiResponse.success(response));
-//    }
-//
+    @PatchMapping("/posts/{post-id}/like")
+    @Operation(summary = "커뮤니티 게시글 좋아요 활성화/비활성화")
+    public ResponseEntity<ApiResponse<Map<String, String>>> toggleLike(
+        @PathVariable("post-id") Long id,
+        @AuthenticationPrincipal Principal principal
+    ) {
+        Long memberId = principal.getMemberId();
+        boolean isLiked = communityService.toggleLike(id, memberId);
+
+        String msg = isLiked ? "좋아요가 등록되었습니다." : "좋아요가 해제되었습니다.";
+        Map<String, String> response = Map.of("message", msg);
+
+        return ResponseEntity
+            .status(ResponseCode.OK.status())
+            .body(ApiResponse.success(response));
+    }
+
 //    @PatchMapping("/posts/{post-id}/bookmark")
 //    @Operation(summary = "커뮤니티 게시글 북마크 활성화/비활성화", description = "현재는 '북마크가 등록되었습니다'만 뜹니다")
 //    public ResponseEntity<ApiResponse<Map<String, String>>> toggleBookmark(

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/community/CommunityController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/community/CommunityController.java
@@ -13,6 +13,7 @@ import com.grepp.spring.app.model.community.dto.CommunityUserInfoResponse;
 import com.grepp.spring.app.model.community.service.CommunityService;
 import com.grepp.spring.app.model.member.domain.Member;
 import com.grepp.spring.app.model.member.service.MemberService;
+import com.grepp.spring.infra.error.exceptions.BadRequestException;
 import com.grepp.spring.infra.payload.PageParam;
 import com.grepp.spring.infra.response.ApiResponse;
 import com.grepp.spring.infra.response.ResponseCode;
@@ -73,9 +74,7 @@ public class CommunityController {
             .anyMatch(c -> c.name().equals(category));
 
         if (!isValidCategory) {
-            return ResponseEntity
-                .status(ResponseCode.BAD_REQUEST.status())
-                .body(ApiResponse.error(ResponseCode.BAD_REQUEST));
+            throw new BadRequestException("유효하지 않은 카테고리입니다.");
         }
 
         List<CommunityPostDetailResponse> posts = communityService.getPostsByCategory(category, pageParam, principal.getMemberId());

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/community/CommunityController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/community/CommunityController.java
@@ -181,26 +181,22 @@ public class CommunityController {
             .body(ApiResponse.successToCreate(response));
     }
 
-//    @PatchMapping("/comments/{comment-id}/delete")
-//    @Operation(summary = "커뮤니티 댓글 삭제")
-//    public ResponseEntity<ApiResponse<Map<String, String>>> deleteComment(
-//        @PathVariable("comment-id") int id
-//    ) {
-//
-//        if (id < 0 || id > 4) {
-//            return ResponseEntity
-//                .status(ResponseCode.NOT_FOUND.status())
-//                .body(ApiResponse.error(ResponseCode.NOT_FOUND));
-//        }
-//
-//        Map<String, String> response = new HashMap<>();
-//        response.put("message", "댓글이 삭제되었습니다.");
-//
-//        return ResponseEntity
-//            .status(ResponseCode.OK.status())
-//            .body(ApiResponse.success(response));
-//    }
-//
+    @PatchMapping("/comments/{comment-id}/delete")
+    @Operation(summary = "커뮤니티 댓글 삭제")
+    public ResponseEntity<ApiResponse<Map<String, String>>> deleteComment(
+        @PathVariable("comment-id") Long id,
+        @AuthenticationPrincipal Principal principal
+    ) {
+        Long memberId = principal.getMemberId();
+        communityService.deleteComment(id, memberId);
+
+        Map<String, String> response = Map.of("message", "댓글이 삭제되었습니다.");
+
+        return ResponseEntity
+            .status(ResponseCode.OK.status())
+            .body(ApiResponse.success(response));
+    }
+
 //    @PatchMapping("/posts/{post-id}/like")
 //    @Operation(summary = "커뮤니티 게시글 좋아요 활성화/비활성화", description = "현재는 '좋아요가 등록되었습니다'만 뜹니다")
 //    public ResponseEntity<ApiResponse<Map<String, String>>> toggleLike(

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/community/CommunityController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/community/CommunityController.java
@@ -214,25 +214,23 @@ public class CommunityController {
             .body(ApiResponse.success(response));
     }
 
-//    @PatchMapping("/posts/{post-id}/bookmark")
-//    @Operation(summary = "커뮤니티 게시글 북마크 활성화/비활성화", description = "현재는 '북마크가 등록되었습니다'만 뜹니다")
-//    public ResponseEntity<ApiResponse<Map<String, String>>> toggleBookmark(
-//        @PathVariable("post-id") int id
-//    ) {
-//        if (id < 0 || id > 4) {
-//            return ResponseEntity
-//                .status(ResponseCode.NOT_FOUND.status())
-//                .body(ApiResponse.error(ResponseCode.NOT_FOUND));
-//        }
-//
-//        Map<String, String> response = new HashMap<>();
-//        response.put("message", "북마크가 등록되었습니다.");
-//
-//        return ResponseEntity
-//            .status(ResponseCode.OK.status())
-//            .body(ApiResponse.success(response));
-//    }
-//
+    @PatchMapping("/posts/{post-id}/bookmark")
+    @Operation(summary = "커뮤니티 게시글 북마크 활성화/비활성화")
+    public ResponseEntity<ApiResponse<Map<String, String>>> toggleBookmark(
+        @PathVariable("post-id") Long id,
+        @AuthenticationPrincipal Principal principal
+    ) {
+        Long memberId = principal.getMemberId();
+        boolean isBookmarked = communityService.toggleBookmark(id, memberId);
+
+        String msg = isBookmarked ? "북마크가 등록되었습니다." : "북마크가 해제되었습니다.";
+        Map<String, String> response = Map.of("message", msg);
+
+        return ResponseEntity
+            .status(ResponseCode.OK.status())
+            .body(ApiResponse.success(response));
+    }
+
 //    @GetMapping("/posts/top")
 //    @Operation(summary = "커뮤니티 인기 게시글 조회")
 //    public ResponseEntity<ApiResponse<List<CommunityTopPostResponse>>> getTopPosts() {

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/community/CommunityController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/community/CommunityController.java
@@ -8,6 +8,7 @@ import com.grepp.spring.app.model.community.dto.CommunityCommentResponse;
 import com.grepp.spring.app.model.community.dto.CommunityPostCreateRequest;
 import com.grepp.spring.app.model.community.dto.CommunityPostDetailResponse;
 import com.grepp.spring.app.model.community.dto.CommunityPostUpdateRequest;
+import com.grepp.spring.app.model.community.dto.CommunityTopPostResponse;
 import com.grepp.spring.app.model.community.dto.CommunityUserInfoResponse;
 import com.grepp.spring.app.model.community.service.CommunityService;
 import com.grepp.spring.app.model.member.domain.Member;
@@ -231,11 +232,13 @@ public class CommunityController {
             .body(ApiResponse.success(response));
     }
 
-//    @GetMapping("/posts/top")
-//    @Operation(summary = "커뮤니티 인기 게시글 조회")
-//    public ResponseEntity<ApiResponse<List<CommunityTopPostResponse>>> getTopPosts() {
-//        return ResponseEntity
-//            .status(ResponseCode.OK.status())
-//            .body(ApiResponse.success(topPosts));
-//    }
+    @GetMapping("/posts/top")
+    @Operation(summary = "커뮤니티 인기 게시글 조회")
+    public ResponseEntity<ApiResponse<List<CommunityTopPostResponse>>> getTopPosts() {
+        List<CommunityTopPostResponse> topPosts = communityService.getTopPosts();
+
+        return ResponseEntity
+            .status(ResponseCode.OK.status())
+            .body(ApiResponse.success(topPosts));
+    }
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/community/CommunityController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/community/CommunityController.java
@@ -3,6 +3,7 @@ package com.grepp.spring.app.controller.api.community;
 import com.google.rpc.context.AttributeContext.Auth;
 import com.grepp.spring.app.model.auth.domain.Principal;
 import com.grepp.spring.app.model.challenge.code.CommunityCategory;
+import com.grepp.spring.app.model.community.dto.CommunityCommentCreateRequest;
 import com.grepp.spring.app.model.community.dto.CommunityCommentResponse;
 import com.grepp.spring.app.model.community.dto.CommunityPostCreateRequest;
 import com.grepp.spring.app.model.community.dto.CommunityPostDetailResponse;
@@ -162,26 +163,24 @@ public class CommunityController {
             .ok(ApiResponse.success(response));
     }
 
-//    @PostMapping("/posts/{post-id}/comments")
-//    @Operation(summary = "커뮤니티 게시글 댓글 작성")
-//    public ResponseEntity<ApiResponse<Map<String, String>>> createComment(
-//        @PathVariable("post-id") int id,
-//        @RequestBody @Valid CommunityCommentCreateRequest request
-//    ) {
-//        Map<String, String> response = new HashMap<>();
-//        response.put("message", "댓글이 생성되었습니다.");
-//
-//        if (id < 0 || id > 4) {
-//            return ResponseEntity
-//                .status(ResponseCode.NOT_FOUND.status())
-//                .body(ApiResponse.error(ResponseCode.NOT_FOUND));
-//        }
-//
-//        return ResponseEntity
-//            .status(ResponseCode.CREATED.status())
-//            .body(ApiResponse.successToCreate(response));
-//    }
-//
+    @PostMapping("/posts/{post-id}/comments")
+    @Operation(summary = "커뮤니티 게시글 댓글 작성")
+    public ResponseEntity<ApiResponse<Map<String, String>>> createComment(
+        @PathVariable("post-id") Long id,
+        @RequestBody @Valid CommunityCommentCreateRequest request,
+        @AuthenticationPrincipal Principal principal
+    ) {
+        Long memberId = principal.getMemberId();
+        Member member = memberService.getMemberById(memberId);
+
+        communityService.createComment(id, request, member);
+        Map<String, String> response = Map.of("message", "댓글이 생성되었습니다.");
+
+        return ResponseEntity
+            .status(ResponseCode.CREATED.status())
+            .body(ApiResponse.successToCreate(response));
+    }
+
 //    @PatchMapping("/comments/{comment-id}/delete")
 //    @Operation(summary = "커뮤니티 댓글 삭제")
 //    public ResponseEntity<ApiResponse<Map<String, String>>> deleteComment(

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/community/CommunityController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/community/CommunityController.java
@@ -3,6 +3,7 @@ package com.grepp.spring.app.controller.api.community;
 import com.google.rpc.context.AttributeContext.Auth;
 import com.grepp.spring.app.model.auth.domain.Principal;
 import com.grepp.spring.app.model.challenge.code.CommunityCategory;
+import com.grepp.spring.app.model.community.dto.CommunityCommentResponse;
 import com.grepp.spring.app.model.community.dto.CommunityPostCreateRequest;
 import com.grepp.spring.app.model.community.dto.CommunityPostDetailResponse;
 import com.grepp.spring.app.model.community.dto.CommunityPostUpdateRequest;
@@ -149,18 +150,18 @@ public class CommunityController {
             .status(ResponseCode.OK.status())
             .body(ApiResponse.success(result));
     }
-//
-//    @GetMapping("/posts/{post-id}/comments")
-//    @Operation(summary = "커뮤니티 게시글별 댓글 조회")
-//    public ResponseEntity<ApiResponse<List<CommunityCommentResponse>>> getCommentsByPostId(
-//        @PathVariable("post-id") int id
-//    ) {
-//
-//        return ResponseEntity
-//            .status(ResponseCode.OK.status())
-//            .body(ApiResponse.success(comments));
-//    }
-//
+
+    @GetMapping("/posts/{post-id}/comments")
+    @Operation(summary = "커뮤니티 게시글별 댓글 조회")
+    public ResponseEntity<ApiResponse<List<CommunityCommentResponse>>> getCommentsByPostId(
+        @PathVariable("post-id") Long id
+    ) {
+        List<CommunityCommentResponse> response = communityService.getCommentsByPostId(id);
+
+        return ResponseEntity
+            .ok(ApiResponse.success(response));
+    }
+
 //    @PostMapping("/posts/{post-id}/comments")
 //    @Operation(summary = "커뮤니티 게시글 댓글 작성")
 //    public ResponseEntity<ApiResponse<Map<String, String>>> createComment(

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/mock/community/MockCommunityController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/mock/community/MockCommunityController.java
@@ -120,25 +120,25 @@ public class MockCommunityController {
 
     List<CommunityTopPostResponse> topPosts = List.of(
         new CommunityTopPostResponse(5L, "작성자 닉네임5", "칭호5", 1, "profile5.jpg", "게시물 제목5",
-            "2025-07-09T07:55:00"),
+            "2025-07-09T07:55:00", "FREE", 12),
         new CommunityTopPostResponse(7L, "작성자 닉네임7", "칭호7", 2, "profile7.jpg", "게시물 제목7",
-            "2025-07-09T16:40:00"),
+            "2025-07-09T16:40:00", "FREE", 146),
         new CommunityTopPostResponse(2L, "작성자 닉네임2", "칭호2", 3, "profile2.jpg", "게시물 제목2",
-            "2025-07-10T08:12:00"),
+            "2025-07-10T08:12:00","FREE",6464),
         new CommunityTopPostResponse(9L, "작성자 닉네임9", "칭호9", 1, "profile9.jpg", "게시물 제목9",
-            "2025-07-10T12:05:00"),
+            "2025-07-10T12:05:00","FREE",12312),
         new CommunityTopPostResponse(0L, "작성자 닉네임0", "칭호0", 4, "profile0.jpg", "게시물 제목0",
-            "2025-07-10T11:32:00"),
+            "2025-07-10T11:32:00","FREE",44),
         new CommunityTopPostResponse(10L, "작성자 닉네임10", "칭호10", 5, "profile10.jpg", "게시물 제목10",
-            "2025-07-09T20:20:00"),
+            "2025-07-09T20:20:00","FREE",1),
         new CommunityTopPostResponse(4L, "작성자 닉네임4", "칭호4", 7, "profile4.jpg", "게시물 제목4",
-            "2025-07-10T13:45:00"),
+            "2025-07-10T13:45:00","FREE",55),
         new CommunityTopPostResponse(6L, "작성자 닉네임6", "칭호6", 1, "profile6.jpg", "게시물 제목6",
-            "2025-07-10T10:22:00"),
+            "2025-07-10T10:22:00","FREE",73),
         new CommunityTopPostResponse(11L, "작성자 닉네임11", "칭호11", 4, "profile11.jpg", "게시물 제목11",
-            "2025-07-10T15:30:00"),
+            "2025-07-10T15:30:00","FREE",123),
         new CommunityTopPostResponse(1L, "작성자 닉네임1", "칭호1", 8, "profile1.jpg", "게시물 제목1",
-            "2025-07-09T14:55:00")
+            "2025-07-09T14:55:00","FREE",73)
     );
 
     @GetMapping("/me")

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/mock/community/MockCommunityController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/mock/community/MockCommunityController.java
@@ -94,27 +94,27 @@ public class MockCommunityController {
     List<String> categories = List.of("나가게", "챌린지", "자유 게시판");
 
     List<CommunityCommentResponse> comments = List.of(
-        new CommunityCommentResponse(0, "댓글 내용0", "댓글 작성자0", "profile0.jpg", "칭호0", 1,
+        new CommunityCommentResponse(0L, 0L,"댓글 내용0", "댓글 작성자0", "profile0.jpg", "칭호0", 1,
             "2025-07-10T09:10:00", "2025-07-10T09:20:00"),
-        new CommunityCommentResponse(1, "댓글 내용1", "댓글 작성자1", "profile1.jpg", "칭호1", 2,
+        new CommunityCommentResponse(1L, 1L,"댓글 내용1", "댓글 작성자1", "profile1.jpg", "칭호1", 2,
             "2025-07-10T10:15:00", "2025-07-10T10:45:00"),
-        new CommunityCommentResponse(2, "댓글 내용2", "댓글 작성자2", "profile2.jpg", "칭호2", 4,
+        new CommunityCommentResponse(2L, 1L,"댓글 내용2", "댓글 작성자2", "profile2.jpg", "칭호2", 4,
             "2025-07-10T08:00:00", "2025-07-10T08:05:00"),
-        new CommunityCommentResponse(3, "댓글 내용3", "댓글 작성자3", "profile3.jpg", "칭호3", 8,
+        new CommunityCommentResponse(3L, 1L,"댓글 내용3", "댓글 작성자3", "profile3.jpg", "칭호3", 8,
             "2025-07-10T11:00:00", "2025-07-10T11:30:00"),
-        new CommunityCommentResponse(4, "댓글 내용4", "댓글 작성자4", "profile4.jpg", "칭호4", 1,
+        new CommunityCommentResponse(4L, 1L,"댓글 내용4", "댓글 작성자4", "profile4.jpg", "칭호4", 1,
             "2025-07-10T13:05:00", "2025-07-10T13:25:00"),
-        new CommunityCommentResponse(5, "댓글 내용5", "댓글 작성자5", "profile5.jpg", "칭호5", 5,
+        new CommunityCommentResponse(5L, 1L,"댓글 내용5", "댓글 작성자5", "profile5.jpg", "칭호5", 5,
             "2025-07-10T07:40:00", "2025-07-10T07:45:00"),
-        new CommunityCommentResponse(6, "댓글 내용6", "댓글 작성자6", "profile6.jpg", "칭호6", 7,
+        new CommunityCommentResponse(6L, 1L,"댓글 내용6", "댓글 작성자6", "profile6.jpg", "칭호6", 7,
             "2025-07-10T14:10:00", "2025-07-10T14:40:00"),
-        new CommunityCommentResponse(7, "댓글 내용7", "댓글 작성자7", "profile7.jpg", "칭호7", 4,
+        new CommunityCommentResponse(7L, 1L,"댓글 내용7", "댓글 작성자7", "profile7.jpg", "칭호7", 4,
             "2025-07-10T15:00:00", "2025-07-10T15:30:00"),
-        new CommunityCommentResponse(8, "댓글 내용8", "댓글 작성자8", "profile8.jpg", "칭호8", 4,
+        new CommunityCommentResponse(8L, 1L,"댓글 내용8", "댓글 작성자8", "profile8.jpg", "칭호8", 4,
             "2025-07-10T09:20:00", "2025-07-10T09:50:00"),
-        new CommunityCommentResponse(9, "댓글 내용9", "댓글 작성자9", "profile9.jpg", "칭호9", 1,
+        new CommunityCommentResponse(9L, 1L,"댓글 내용9", "댓글 작성자9", "profile9.jpg", "칭호9", 1,
             "2025-07-10T12:00:00", "2025-07-10T12:15:00"),
-        new CommunityCommentResponse(10, "댓글 내용10", "댓글 작성자10", "profile10.jpg", "칭호10", 4,
+        new CommunityCommentResponse(10L, 1L,"댓글 내용10", "댓글 작성자10", "profile10.jpg", "칭호10", 4,
             "2025-07-10T12:10:00", "2025-07-10T12:45:00")
     );
 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/domain/CommunityPost.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/domain/CommunityPost.java
@@ -36,7 +36,7 @@ public class CommunityPost extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @JoinColumn(name = "post_id", nullable = false)
+    @Column(name = "post_id", nullable = false)
     private Long postId;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -48,6 +48,12 @@ public class CommunityPost extends BaseEntity {
 
     @Column(nullable = false)
     private String content;
+
+    @Column(nullable = false)
+    private int likeCount = 0;
+
+    @Column(nullable = false)
+    private int commentCount = 0;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/dto/CommunityCommentResponse.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/dto/CommunityCommentResponse.java
@@ -5,7 +5,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "커뮤니티 댓글 응답 DTO")
 public record CommunityCommentResponse(
     @Schema(description = "댓글 고유식별번호", example = "0")
-    int commentId,
+    Long commentId,
+
+    @Schema(description = "사용자 고유식별번호", example = "0")
+    Long memberId,
 
     @Schema(description = "댓글 내용", example = "댓글 내용")
     String content,

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/dto/CommunityTopPostResponse.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/dto/CommunityTopPostResponse.java
@@ -24,8 +24,13 @@ public record CommunityTopPostResponse(
     String title,
 
     @Schema(description = "게시글 작성일", example = "2025-07-03T14:20:00")
-    String createdAt
+    String createdAt,
 
+    @Schema(description = "게시글 카테고리", example = "FREE")
+    String category,
+
+    @Schema(description = "좋아요 수", example = "55")
+    int likeCount
 ) {
 
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityBookmarkRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityBookmarkRepository.java
@@ -1,8 +1,14 @@
 package com.grepp.spring.app.model.community.repos;
 
 import com.grepp.spring.app.model.community.domain.CommunityBookmark;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommunityBookmarkRepository extends JpaRepository<CommunityBookmark, Long> {
+
+    // 커뮤니티 현재 사용자의 활성화된 북마크가 존재하는지 확인
+    Optional<CommunityBookmark> findByPost_PostIdAndMember_MemberId(Long postId, Long memberId);
+
+    // 커뮤니티 북마크 활성화 여부
     boolean existsByPost_PostIdAndMember_MemberId(Long postId, Long memberId);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityCommentRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityCommentRepository.java
@@ -10,12 +10,13 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface CommunityCommentRepository extends JpaRepository<CommunityComment, Long> {
 
+    // 커뮤니티 게시글 댓글 수
     @Query("SELECT COUNT(c) FROM CommunityComment c WHERE c.post.postId = :postId")
     int countCommentByPostId(@Param("postId") Long postId);
 
-    // 게시글 댓글 조회
+    // 커뮤니티 게시글 댓글 조회
     List<CommunityComment> findByPost_PostIdAndActivatedTrue(Long postId);
 
-    // 게시글 댓글 삭제
+    // 커뮤니티 게시글 댓글 삭제
     Optional<CommunityComment> findByCommentIdAndActivatedTrue(Long commentId);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityCommentRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityCommentRepository.java
@@ -4,6 +4,7 @@ import com.grepp.spring.app.model.community.domain.CommunityComment;
 import com.grepp.spring.app.model.community.domain.CommunityLike;
 import feign.Param;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -14,4 +15,7 @@ public interface CommunityCommentRepository extends JpaRepository<CommunityComme
 
     // 게시글 댓글 조회
     List<CommunityComment> findByPost_PostIdAndActivatedTrue(Long postId);
+
+    // 게시글 댓글 삭제
+    Optional<CommunityComment> findByCommentIdAndActivatedTrue(Long commentId);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityCommentRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityCommentRepository.java
@@ -11,8 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 public interface CommunityCommentRepository extends JpaRepository<CommunityComment, Long> {
 
     // 커뮤니티 게시글 댓글 수
-    @Query("SELECT COUNT(c) FROM CommunityComment c WHERE c.post.postId = :postId")
-    int countCommentByPostId(@Param("postId") Long postId);
+    int countByPost_PostIdAndActivatedTrue(Long postId);
 
     // 커뮤니티 게시글 댓글 조회
     List<CommunityComment> findByPost_PostIdAndActivatedTrue(Long postId);

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityCommentRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityCommentRepository.java
@@ -3,6 +3,7 @@ package com.grepp.spring.app.model.community.repos;
 import com.grepp.spring.app.model.community.domain.CommunityComment;
 import com.grepp.spring.app.model.community.domain.CommunityLike;
 import feign.Param;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -11,4 +12,6 @@ public interface CommunityCommentRepository extends JpaRepository<CommunityComme
     @Query("SELECT COUNT(c) FROM CommunityComment c WHERE c.post.postId = :postId")
     int countCommentByPostId(@Param("postId") Long postId);
 
+    // 게시글 댓글 조회
+    List<CommunityComment> findByPost_PostIdAndActivatedTrue(Long postId);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityLikeRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityLikeRepository.java
@@ -1,16 +1,17 @@
 package com.grepp.spring.app.model.community.repos;
 
 import com.grepp.spring.app.model.community.domain.CommunityLike;
-import feign.Param;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface CommunityLikeRepository extends JpaRepository<CommunityLike, Long> {
-    @Query("SELECT COUNT(c) FROM CommunityLike c WHERE c.post.postId = :postId")
-    int countLikeByPostId(@Param("postId") Long postId);
 
+    // 커뮤니티 활성화된 좋아요 개수
+    int countLikeByPost_PostIdAndActivatedTrue(Long postId);
+
+    // 커뮤니티 좋아요 활성화 여부
     boolean existsByPost_PostIdAndMember_MemberId(Long postId, Long memberId);
 
+    // 커뮤니티 현재 사용자의 활성화된 좋아요가 존재하는지 확인
     Optional<CommunityLike> findByPost_PostIdAndMember_MemberId(Long postId, Long memberId);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityLikeRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityLikeRepository.java
@@ -2,6 +2,7 @@ package com.grepp.spring.app.model.community.repos;
 
 import com.grepp.spring.app.model.community.domain.CommunityLike;
 import feign.Param;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -10,4 +11,6 @@ public interface CommunityLikeRepository extends JpaRepository<CommunityLike, Lo
     int countLikeByPostId(@Param("postId") Long postId);
 
     boolean existsByPost_PostIdAndMember_MemberId(Long postId, Long memberId);
+
+    Optional<CommunityLike> findByPost_PostIdAndMember_MemberId(Long postId, Long memberId);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityRepository.java
@@ -2,14 +2,25 @@ package com.grepp.spring.app.model.community.repos;
 
 import com.grepp.spring.app.model.challenge.code.CommunityCategory;
 import com.grepp.spring.app.model.community.domain.CommunityPost;
+import feign.Param;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CommunityRepository extends JpaRepository<CommunityPost, Long> {
 
+    // 커뮤니티 게시글 카테고리별 조회
     Page<CommunityPost> findByCategoryAndActivatedIsTrue(CommunityCategory category, Pageable pageable);
 
+    // 커뮤니티 게시글 존재 여부 판별
     Optional<CommunityPost> findByPostIdAndActivatedIsTrue(Long postId);
+
+    // 커뮤니티 게시글 단건 조회 + 비관적 락
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM CommunityPost p WHERE p.postId = :postId AND p.activated = true")
+    Optional<CommunityPost> findActivatedPostWithLock(@Param("postId") Long postId);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityRepository.java
@@ -4,6 +4,7 @@ import com.grepp.spring.app.model.challenge.code.CommunityCategory;
 import com.grepp.spring.app.model.community.domain.CommunityPost;
 import feign.Param;
 import jakarta.persistence.LockModeType;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,4 +24,7 @@ public interface CommunityRepository extends JpaRepository<CommunityPost, Long> 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM CommunityPost p WHERE p.postId = :postId AND p.activated = true")
     Optional<CommunityPost> findActivatedPostWithLock(@Param("postId") Long postId);
+
+    // 커뮤니티 인기 게시글 조회
+    List<CommunityPost> findTop10ByActivatedIsTrueOrderByLikeCountDesc();
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityService.java
@@ -41,4 +41,7 @@ public interface CommunityService {
 
     // 게시글 좋아요 활성화/비활성화
     boolean toggleLike(Long postId, Long memberId);
+
+    // 게시글 북마크 활성화/비활성화
+    boolean toggleBookmark(Long postId, Long memberId);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityService.java
@@ -33,6 +33,9 @@ public interface CommunityService {
     // 게시글 댓글 조회
     List<CommunityCommentResponse> getCommentsByPostId(Long postId);
 
-    // 게시물 댓글 작성
+    // 게시글 댓글 작성
     void createComment(Long postId, CommunityCommentCreateRequest request, Member member);
+
+    // 게시글 댓글 삭제
+    void deleteComment(Long commentId, Long memberId);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityService.java
@@ -38,4 +38,7 @@ public interface CommunityService {
 
     // 게시글 댓글 삭제
     void deleteComment(Long commentId, Long memberId);
+
+    // 게시글 좋아요 활성화/비활성화
+    boolean toggleLike(Long postId, Long memberId);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityService.java
@@ -1,5 +1,6 @@
 package com.grepp.spring.app.model.community.service;
 
+import com.grepp.spring.app.model.community.dto.CommunityCommentResponse;
 import com.grepp.spring.app.model.community.dto.CommunityPostCreateRequest;
 import com.grepp.spring.app.model.community.dto.CommunityPostDetailResponse;
 import com.grepp.spring.app.model.community.dto.CommunityPostUpdateRequest;
@@ -27,4 +28,7 @@ public interface CommunityService {
 
     // 커뮤니티 게시글 단건 조회
     CommunityPostDetailResponse getPostById(Long postId, Long memberId);
+
+    // 게시글 댓글 조회
+    List<CommunityCommentResponse> getCommentsByPostId(Long postId);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityService.java
@@ -5,6 +5,7 @@ import com.grepp.spring.app.model.community.dto.CommunityCommentResponse;
 import com.grepp.spring.app.model.community.dto.CommunityPostCreateRequest;
 import com.grepp.spring.app.model.community.dto.CommunityPostDetailResponse;
 import com.grepp.spring.app.model.community.dto.CommunityPostUpdateRequest;
+import com.grepp.spring.app.model.community.dto.CommunityTopPostResponse;
 import com.grepp.spring.app.model.community.dto.CommunityUserInfoResponse;
 import com.grepp.spring.app.model.member.domain.Member;
 import com.grepp.spring.infra.payload.PageParam;
@@ -30,18 +31,21 @@ public interface CommunityService {
     // 커뮤니티 게시글 단건 조회
     CommunityPostDetailResponse getPostById(Long postId, Long memberId);
 
-    // 게시글 댓글 조회
+    // 커뮤니티 게시글 댓글 조회
     List<CommunityCommentResponse> getCommentsByPostId(Long postId);
 
-    // 게시글 댓글 작성
+    // 커뮤니티 게시글 댓글 작성
     void createComment(Long postId, CommunityCommentCreateRequest request, Member member);
 
-    // 게시글 댓글 삭제
+    // 커뮤니티 게시글 댓글 삭제
     void deleteComment(Long commentId, Long memberId);
 
-    // 게시글 좋아요 활성화/비활성화
+    // 커뮤니티 게시글 좋아요 활성화/비활성화
     boolean toggleLike(Long postId, Long memberId);
 
-    // 게시글 북마크 활성화/비활성화
+    // 커뮤니티 게시글 북마크 활성화/비활성화
     boolean toggleBookmark(Long postId, Long memberId);
+
+    // 커뮤니티 인기 게시글 조회
+    List<CommunityTopPostResponse> getTopPosts();
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityService.java
@@ -1,5 +1,6 @@
 package com.grepp.spring.app.model.community.service;
 
+import com.grepp.spring.app.model.community.dto.CommunityCommentCreateRequest;
 import com.grepp.spring.app.model.community.dto.CommunityCommentResponse;
 import com.grepp.spring.app.model.community.dto.CommunityPostCreateRequest;
 import com.grepp.spring.app.model.community.dto.CommunityPostDetailResponse;
@@ -31,4 +32,7 @@ public interface CommunityService {
 
     // 게시글 댓글 조회
     List<CommunityCommentResponse> getCommentsByPostId(Long postId);
+
+    // 게시물 댓글 작성
+    void createComment(Long postId, CommunityCommentCreateRequest request, Member member);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
@@ -81,21 +81,10 @@ public class CommunityServiceImpl implements CommunityService {
 
         communityRepository.save(post);
 
-        List<String> imgUrls = request.imageUrls();
-        if (imgUrls != null && imgUrls.size() > 8) {
-            throw new BadRequestException("이미지는 최대 8개까지 등록할 수 있습니다.");
-        }
-
-        if (imgUrls != null && !imgUrls.isEmpty()) {
-            List<PostImage> images = new ArrayList<>();
-            for (int i = 0; i < imgUrls.size(); i++) {
-                images.add(PostImage.builder()
-                    .post(post)
-                    .imageUrl(imgUrls.get(i))
-                    .sortOrder(i)
                     .build());
-            }
-            postImageRepository.saveAll(images);
+        List<String> imageUrls = request.imageUrls();
+        if (imageUrls != null && !imageUrls.isEmpty()) {
+            postImageService.addPostImages(post, imageUrls);
         }
     }
 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
@@ -19,6 +19,7 @@ import com.grepp.spring.app.model.community.repos.CommunityLikeRepository;
 import com.grepp.spring.app.model.community.repos.CommunityRepository;
 import com.grepp.spring.app.model.member.domain.Member;
 import com.grepp.spring.app.model.member.service.MemberService;
+import com.grepp.spring.app.model.notification.service.NotificationService;
 import com.grepp.spring.app.model.post_image.domain.PostImage;
 import com.grepp.spring.app.model.post_image.repos.PostImageRepository;
 import com.grepp.spring.app.model.post_image.service.PostImageService;
@@ -42,6 +43,7 @@ public class CommunityServiceImpl implements CommunityService {
 
     private final PostImageService postImageService;
     private final MemberService memberService;
+    private final NotificationService notificationService;
     private final CommunityRepository communityRepository;
     private final CommunityCommentRepository commentRepository;
     private final CommunityLikeRepository likeRepository;
@@ -257,6 +259,12 @@ public class CommunityServiceImpl implements CommunityService {
 
         commentRepository.save(comment);
         post.setCommentCount(post.getCommentCount() + 1);
+
+        // 알림 생성
+        Long receiverId = post.getMember().getMemberId();
+        Long senderId = member.getMemberId();
+
+        notificationService.createNotification(receiverId, senderId, "COMMENT");
     }
 
     // 게시물 댓글 삭제
@@ -298,6 +306,8 @@ public class CommunityServiceImpl implements CommunityService {
                 // 비활성화 → 활성화
                 like.activate();
                 post.setLikeCount(post.getLikeCount() + 1);
+                // 알림 생성
+                notificationService.createNotification(post.getMember().getMemberId(), memberId, "LIKE");
                 return true;
             }
         } else {
@@ -308,6 +318,7 @@ public class CommunityServiceImpl implements CommunityService {
                 .build();
             likeRepository.save(newLike);
             post.setLikeCount(post.getLikeCount() + 1);
+            notificationService.createNotification(post.getMember().getMemberId(), memberId, "LIKE");
             return true;
         }
     }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
@@ -2,7 +2,9 @@ package com.grepp.spring.app.model.community.service;
 
 import com.grepp.spring.app.model.challenge.code.ChallengeCategory;
 import com.grepp.spring.app.model.challenge.code.CommunityCategory;
+import com.grepp.spring.app.model.community.domain.CommunityComment;
 import com.grepp.spring.app.model.community.domain.CommunityPost;
+import com.grepp.spring.app.model.community.dto.CommunityCommentResponse;
 import com.grepp.spring.app.model.community.dto.CommunityPostCreateRequest;
 import com.grepp.spring.app.model.community.dto.CommunityPostDetailResponse;
 import com.grepp.spring.app.model.community.dto.CommunityPostUpdateRequest;
@@ -211,6 +213,33 @@ public class CommunityServiceImpl implements CommunityService {
             post.getMember().getLevel() != null ? post.getMember().getLevel() : 0,
             post.getMember().getProfileImage()
         );
+    }
+
+    // 게시글 댓글 조회
+    @Override
+    @Transactional(readOnly = true)
+    public List<CommunityCommentResponse> getCommentsByPostId(Long postId) {
+
+        if (!communityRepository.existsById(postId)) {
+            throw new NotFoundException("해당 게시글이 존재하지 않습니다.");
+        }
+
+        List<CommunityComment> comments = commentRepository.findByPost_PostIdAndActivatedTrue(postId);
+
+        return comments.stream()
+            .map(comment -> new CommunityCommentResponse(
+                comment.getCommentId(),
+                comment.getMember().getMemberId(),
+                comment.getContent(),
+                comment.getMember().getNickname(),
+                comment.getMember().getProfileImage(),
+                // TODO : member 엔티티 수정되면 다시 수정해야함
+                comment.getMember().getEquippedTitle() != null ? comment.getMember().getEquippedTitle().getName() : null,
+                comment.getMember().getLevel() != null ? comment.getMember().getLevel() : 0,
+                comment.getCreatedAt().toString(),
+                comment.getModifiedAt().toString()
+            ))
+            .toList();
     }
 
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
@@ -261,6 +261,15 @@ public class CommunityServiceImpl implements CommunityService {
     @Override
     public void deleteComment(Long commentId, Long memberId) {
 
+        // 존재하는 댓글인지 검증
+        CommunityComment comment = getActivatedComment(commentId);
+
+        // 해당 댓글 작성자인지 검증
+        if (!comment.getMember().getMemberId().equals(memberId)) {
+            throw new AuthorizationDeniedException("댓글 삭제 권한이 없습니다.");
+        }
+
+        comment.unActivated();
     }
 
     // 존재하는 게시물인지 검증 메서드
@@ -269,4 +278,9 @@ public class CommunityServiceImpl implements CommunityService {
             .orElseThrow(() -> new NotFoundException("존재하지 않거나 삭제된 게시글입니다."));
     }
 
+    // 존재하는 댓글인지 검증 메서드
+    private CommunityComment getActivatedComment(Long commentId) {
+        return commentRepository.findByCommentIdAndActivatedTrue(commentId)
+            .orElseThrow(() -> new NotFoundException("존재하지 않거나 이미 삭제된 댓글입니다."));
+    }
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -103,7 +104,7 @@ public class CommunityServiceImpl implements CommunityService {
     @Transactional(readOnly = true)
     public List<CommunityPostDetailResponse> getPostsByCategory(String category, PageParam pageParam, Long memberId) {
         CommunityCategory categoryEnum = CommunityCategory.valueOf(category);
-        Pageable pageable = pageParam.toPageable();
+        Pageable pageable = pageParam.toPageable(Sort.by(Sort.Direction.DESC,"createdAt"));
         Page<CommunityPost> posts =  communityRepository.findByCategoryAndActivatedIsTrue(categoryEnum, pageable);
 
         return posts.stream()

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
@@ -258,6 +258,11 @@ public class CommunityServiceImpl implements CommunityService {
         commentRepository.save(comment);
     }
 
+    @Override
+    public void deleteComment(Long commentId, Long memberId) {
+
+    }
+
     // 존재하는 게시물인지 검증 메서드
     private CommunityPost getActivatedPost(Long postId) {
         return communityRepository.findByPostIdAndActivatedIsTrue(postId)

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
@@ -81,7 +81,6 @@ public class CommunityServiceImpl implements CommunityService {
 
         communityRepository.save(post);
 
-                    .build());
         List<String> imageUrls = request.imageUrls();
         if (imageUrls != null && !imageUrls.isEmpty()) {
             postImageService.addPostImages(post, imageUrls);

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
@@ -23,6 +23,7 @@ import com.grepp.spring.app.model.notification.service.NotificationService;
 import com.grepp.spring.app.model.post_image.domain.PostImage;
 import com.grepp.spring.app.model.post_image.repos.PostImageRepository;
 import com.grepp.spring.app.model.post_image.service.PostImageService;
+import com.grepp.spring.infra.error.exceptions.BadRequestException;
 import com.grepp.spring.infra.payload.PageParam;
 import com.grepp.spring.util.NotFoundException;
 import java.util.ArrayList;
@@ -80,6 +81,10 @@ public class CommunityServiceImpl implements CommunityService {
         communityRepository.save(post);
 
         List<String> imgUrls = request.imageUrls();
+        if (imgUrls != null && imgUrls.size() > 8) {
+            throw new BadRequestException("이미지는 최대 8개까지 등록할 수 있습니다.");
+        }
+
         if (imgUrls != null && !imgUrls.isEmpty()) {
             List<PostImage> images = new ArrayList<>();
             for (int i = 0; i < imgUrls.size(); i++) {
@@ -223,7 +228,7 @@ public class CommunityServiceImpl implements CommunityService {
     public List<CommunityCommentResponse> getCommentsByPostId(Long postId) {
 
         // 존재하는 게시물인지 검증
-        CommunityPost post = getActivatedPost(postId);
+        getActivatedPost(postId);
 
         List<CommunityComment> comments = commentRepository.findByPost_PostIdAndActivatedTrue(postId);
 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/post_image/service/PostImageService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/post_image/service/PostImageService.java
@@ -6,5 +6,5 @@ import java.util.List;
 public interface PostImageService {
 
     void updatePostImages(CommunityPost post, List<String> updatedImageUrls);
-
+    void addPostImages(CommunityPost post, List<String> imageUrls);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/post_image/service/PostImageServiceImpl.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/post_image/service/PostImageServiceImpl.java
@@ -3,6 +3,7 @@ package com.grepp.spring.app.model.post_image.service;
 import com.grepp.spring.app.model.community.domain.CommunityPost;
 import com.grepp.spring.app.model.post_image.domain.PostImage;
 import com.grepp.spring.app.model.post_image.repos.PostImageRepository;
+import com.grepp.spring.infra.error.exceptions.BadRequestException;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,6 +22,11 @@ public class PostImageServiceImpl implements PostImageService{
     @Transactional
     @Override
     public void updatePostImages(CommunityPost post, List<String> updatedImageUrls) {
+
+        if (updatedImageUrls.size() > 8) {
+            throw new BadRequestException("이미지는 최대 8개까지만 업로드할 수 있습니다.");
+        }
+
         Set<PostImage> currentImages = post.getImages();
 
         // 기존 이미지와 새로운 이미지 요청 비교

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/post_image/service/PostImageServiceImpl.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/post_image/service/PostImageServiceImpl.java
@@ -62,4 +62,27 @@ public class PostImageServiceImpl implements PostImageService{
             postImageRepository.saveAll(toAdd);
         }
     }
+
+    @Transactional
+    @Override
+    public void addPostImages(CommunityPost post, List<String> imageUrls) {
+
+        if (imageUrls.size() > 8) {
+            throw new BadRequestException("이미지는 최대 8개까지 등록할 수 있습니다.");
+        }
+
+        // 새로운 이미지
+        List<PostImage> images = new ArrayList<>();
+        for (int i = 0; i < imageUrls.size(); i++) {
+            images.add(PostImage.builder()
+                .post(post)
+                .imageUrl(imageUrls.get(i))
+                .sortOrder(i)
+                .build());
+        }
+
+        postImageRepository.saveAll(images);
+    }
+
+
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/entity/BaseEntity.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/entity/BaseEntity.java
@@ -25,4 +25,8 @@ public class BaseEntity {
     public void unActivated(){
         this.activated = false;
     }
+
+    public void activate() {
+        this.activated = true;
+    }
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/error/RestApiExceptionAdvice.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/error/RestApiExceptionAdvice.java
@@ -1,5 +1,6 @@
 package com.grepp.spring.infra.error;
 
+import com.grepp.spring.infra.error.exceptions.BadRequestException;
 import com.grepp.spring.infra.error.exceptions.CommonException;
 import com.grepp.spring.infra.response.ApiResponse;
 import com.grepp.spring.infra.response.ResponseCode;
@@ -71,6 +72,12 @@ public class RestApiExceptionAdvice {
                    .internalServerError()
                    .body(ApiResponse.error(ResponseCode.INTERNAL_SERVER_ERROR));
     }
-    
-    
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ApiResponse<String>> handleBadRequest(BadRequestException ex) {
+        log.error(ex.getMessage(), ex);
+        return ResponseEntity
+            .status(ResponseCode.BAD_REQUEST.status())
+            .body(ApiResponse.error(ResponseCode.BAD_REQUEST, ex.getMessage()));
+    }
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/error/exceptions/BadRequestException.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/error/exceptions/BadRequestException.java
@@ -1,0 +1,11 @@
+package com.grepp.spring.infra.error.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+      super(message);
+    }
+}

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/payload/PageParam.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/payload/PageParam.java
@@ -19,7 +19,7 @@ public class PageParam{
     @Min(1)
     private int size = 10;
 
-    public Pageable toPageable() {
-        return PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC,"createdAt"));
+    public Pageable toPageable(Sort sort) {
+        return PageRequest.of(page - 1, size, sort);
     }
 }


### PR DESCRIPTION
✨ 커뮤니티 기능 API

- 커뮤니티 게시글별 댓글 조회 : (GET) /api/community/posts/{post-id}/comments
- 커뮤니티 게시글 댓글 작성 : (POST) /api/community/posts/{post-id}/comments
- 커뮤니티 게시글 댓글 삭제 : (PATCH) /api/community/comments/{comment-id}/delete
- 커뮤니티 게시글 좋아요 활성화/비활성화 : (PATCH) /api/community/posts/{post-id}/like
- 커뮤니티 게시글 북마크 활성화/비활성화 : (PATCH) /api/community/posts/{post-id}/bookmark
- 커뮤니티 인기 게시글 조회 : (GET) /api/community/posts/top
- 댓글 작성, 좋아요 활성화시 notification 데이터베이스에 추가

📦 공통/구조 정비

- mock 더미데이터 추가
- BaseEntity 비활성화 -> 활성화 메서드 추가
- CommunitPost 엔티티 필드 추가
- Dto 필드 추가
- activated true인 값만 조회할 수 있도록 repository 메서드 수정
- 동시성 문제를 해결하기 위해 게시물 댓글 작성, 삭제, 좋아요 활성화/비활성화는 비관적 락 적용
- 이미지 업로드 개수 제한