### PR TITLE
feat: 마이페이지 및 회원 관리 기능 구현

### DIFF
--- a/apimocking-main/apimocking-boilerplate/pom.xml
+++ b/apimocking-main/apimocking-boilerplate/pom.xml
@@ -143,6 +143,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
+      <version>1.18.32</version>
       <optional>true</optional>
     </dependency>
 
@@ -258,6 +259,17 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>21</source>
+          <target>21</target>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>1.18.32</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/community/CommunityController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/community/CommunityController.java
@@ -240,4 +240,6 @@ public class CommunityController {
             .status(ResponseCode.OK.status())
             .body(ApiResponse.success(topPosts));
     }
+
+
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
@@ -410,6 +410,19 @@ public class MemberController {
         return ResponseEntity.ok(ApiResponse.success(Map.of()));
     }
 
+    @PatchMapping("/withdraw")
+    @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자의 계정을 비활성화합니다.")
+    public ResponseEntity<ApiResponse<Object>> withdrawMember() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Principal principal = (Principal) authentication.getPrincipal();
+        Long memberId = principal.getMemberId();
+        
+        // 회원 탈퇴 처리 (activated = false)
+        memberService.withdrawMember(memberId);
+        
+        return ResponseEntity.ok(ApiResponse.success(Map.of()));
+    }
+
     @GetMapping("/mypage")
     @Operation(summary = "마이페이지 조회", description = "현재 로그인한 사용자의 마이페이지 정보를 조회합니다.")
     public ResponseEntity<ApiResponse<MypageResponse>> getMypage() {

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
@@ -554,9 +554,13 @@ public class MemberController {
         @Pattern(regexp = "^01[016789]\\d{7,8}$", message = "휴대폰번호 형식이 올바르지 않습니다.")
         private String phoneNumber;
     }
-    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
+    @Getter @Setter @NoArgsConstructor
     public static class SignupResponse {
         private Long userId;
+        
+        public SignupResponse(Long userId) {
+            this.userId = userId;
+        }
     }
     @Getter @Setter @NoArgsConstructor @AllArgsConstructor
     public static class CheckEmailRequest {
@@ -566,9 +570,13 @@ public class MemberController {
     public static class CheckNicknameRequest {
         private String nickname;
     }
-    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
+    @Getter @Setter @NoArgsConstructor
     public static class CheckResponse {
         private boolean available;
+        
+        public CheckResponse(boolean available) {
+            this.available = available;
+        }
     }
     @Getter @Setter @NoArgsConstructor @AllArgsConstructor
     public static class LoginRequest {
@@ -577,9 +585,14 @@ public class MemberController {
         @Schema(description = "비밀번호", example = "string")
         private String password;
     }
-    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
+    @Getter @Setter @NoArgsConstructor
     public static class LoginResponse {
         private Data data;
+        
+        public LoginResponse(Data data) {
+            this.data = data;
+        }
+        
         @Getter @Setter @NoArgsConstructor @AllArgsConstructor
         public static class Data {
             private String accessToken;
@@ -602,10 +615,14 @@ public class MemberController {
         private String phoneNumber;
     }
 
-    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
+    @Getter @Setter @NoArgsConstructor
     public static class FindEmailResponse {
         @Schema(description = "마스킹된 이메일 목록", example = "[\"te****@test.com\", \"an****@test.com\"]")
         private java.util.List<String> emails;
+        
+        public FindEmailResponse(java.util.List<String> emails) {
+            this.emails = emails;
+        }
     }
 
     // 비밀번호 찾기 관련 DTO
@@ -658,9 +675,14 @@ public class MemberController {
     }
 
     // 마이페이지 조회 응답 DTO
-    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
+    @Getter @Setter @NoArgsConstructor
     public static class MypageResponse {
         private Data data;
+        
+        public MypageResponse(Data data) {
+            this.data = data;
+        }
+        
         @Getter @Setter @NoArgsConstructor @AllArgsConstructor
         public static class Data {
             private Long memberId;

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget/service/BudgetService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget/service/BudgetService.java
@@ -10,6 +10,9 @@ import com.grepp.spring.app.model.member.repos.MemberRepository;
 import com.grepp.spring.util.NotFoundException;
 import com.grepp.spring.util.ReferencedWarning;
 import java.util.List;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
@@ -57,6 +60,29 @@ public class BudgetService {
 
     public void delete(final Long budgetId) {
         budgetRepository.deleteById(budgetId);
+    }
+
+    // 현재 달의 총 수입과 총 지출 조회
+    public BigDecimal[] getCurrentMonthTotal(Long memberId) {
+        YearMonth currentYearMonth = YearMonth.now();
+        LocalDate startOfMonth = currentYearMonth.atDay(1);
+        LocalDate endOfMonth = currentYearMonth.atEndOfMonth();
+        
+        List<Budget> monthlyBudgets = budgetRepository.findByMember_MemberIdAndDateBetween(memberId, startOfMonth, endOfMonth);
+        
+        BigDecimal totalIncome = BigDecimal.ZERO;
+        BigDecimal totalExpense = BigDecimal.ZERO;
+        
+        for (Budget budget : monthlyBudgets) {
+            if (budget.getTotalIncome() != null) {
+                totalIncome = totalIncome.add(budget.getTotalIncome());
+            }
+            if (budget.getTotalExpense() != null) {
+                totalExpense = totalExpense.add(budget.getTotalExpense());
+            }
+        }
+        
+        return new BigDecimal[]{totalIncome, totalExpense};
     }
 
     private BudgetDTO mapToDTO(final Budget budget, final BudgetDTO budgetDTO) {

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget/service/BudgetService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget/service/BudgetService.java
@@ -68,7 +68,11 @@ public class BudgetService {
         LocalDate startOfMonth = currentYearMonth.atDay(1);
         LocalDate endOfMonth = currentYearMonth.atEndOfMonth();
         
-        List<Budget> monthlyBudgets = budgetRepository.findByMember_MemberIdAndDateBetween(memberId, startOfMonth, endOfMonth);
+        // Member 객체를 먼저 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException("Member not found"));
+        
+        List<Budget> monthlyBudgets = budgetRepository.findAllByMemberAndDateBetweenOrderByDateAsc(member, startOfMonth, endOfMonth);
         
         BigDecimal totalIncome = BigDecimal.ZERO;
         BigDecimal totalExpense = BigDecimal.ZERO;

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityBookmarkRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityBookmarkRepository.java
@@ -1,6 +1,7 @@
 package com.grepp.spring.app.model.community.repos;
 
 import com.grepp.spring.app.model.community.domain.CommunityBookmark;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,4 +12,7 @@ public interface CommunityBookmarkRepository extends JpaRepository<CommunityBook
 
     // 커뮤니티 북마크 활성화 여부
     boolean existsByPost_PostIdAndMember_MemberId(Long postId, Long memberId);
+
+    // 내가 북마크한 게시글 목록 조회
+    List<CommunityBookmark> findByMember_MemberIdAndActivatedTrue(Long memberId);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/repos/CommunityRepository.java
@@ -27,4 +27,7 @@ public interface CommunityRepository extends JpaRepository<CommunityPost, Long> 
 
     // 커뮤니티 인기 게시글 조회
     List<CommunityPost> findTop10ByActivatedIsTrueOrderByLikeCountDesc();
+
+    // 내가 작성한 게시글 목록 조회
+    List<CommunityPost> findByMember_MemberIdAndActivatedIsTrue(Long memberId);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityService.java
@@ -10,6 +10,7 @@ import com.grepp.spring.app.model.community.dto.CommunityUserInfoResponse;
 import com.grepp.spring.app.model.member.domain.Member;
 import com.grepp.spring.infra.payload.PageParam;
 import java.util.List;
+import java.util.Map;
 
 public interface CommunityService {
 
@@ -48,4 +49,10 @@ public interface CommunityService {
 
     // 커뮤니티 인기 게시글 조회
     List<CommunityTopPostResponse> getTopPosts();
+
+    // 내가 작성한 게시글 목록 조회 (마이페이지용)
+    List<Map<String, Object>> getMyPosts(Long memberId);
+
+    // 내가 북마크한 게시글 목록 조회 (마이페이지용)
+    List<Map<String, Object>> getBookmarkedPosts(Long memberId);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
@@ -27,7 +27,9 @@ import com.grepp.spring.infra.error.exceptions.BadRequestException;
 import com.grepp.spring.infra.payload.PageParam;
 import com.grepp.spring.util.NotFoundException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -384,5 +386,74 @@ public class CommunityServiceImpl implements CommunityService {
     private CommunityComment getActivatedComment(Long commentId) {
         return commentRepository.findByCommentIdAndActivatedTrue(commentId)
             .orElseThrow(() -> new NotFoundException("존재하지 않거나 이미 삭제된 댓글입니다."));
+    }
+
+    // 내가 작성한 게시글 목록 조회 (마이페이지용)
+    @Override
+    @Transactional(readOnly = true)
+    public List<Map<String, Object>> getMyPosts(Long memberId) {
+        List<CommunityPost> posts = communityRepository.findByMember_MemberIdAndActivatedIsTrue(memberId);
+        
+        return posts.stream()
+            .map(post -> {
+                Map<String, Object> postMap = new HashMap<>();
+                postMap.put("postId", post.getPostId());
+                postMap.put("memberId", post.getMember().getMemberId());
+                postMap.put("category", post.getCategory().toString());
+                postMap.put("challengeCategory", post.getChallenge() != null ? post.getChallenge().toString() : null);
+                postMap.put("title", post.getTitle());
+                postMap.put("createdAt", post.getCreatedAt().toString());
+                postMap.put("content", post.getContent());
+                
+                // 이미지 URL 목록
+                List<String> imageUrls = post.getImages().stream()
+                    .filter(image -> image.getActivated())
+                    .map(image -> image.getImageUrl())
+                    .toList();
+                postMap.put("imageUrls", imageUrls);
+                
+                postMap.put("commentCount", post.getCommentCount());
+                postMap.put("likeCount", post.getLikeCount());
+                
+                // 현재 사용자가 좋아요를 눌렀는지 확인
+                boolean isLiked = post.getLiked().stream()
+                    .anyMatch(like -> like.getMember().getMemberId().equals(memberId) && like.getActivated());
+                postMap.put("isLiked", isLiked);
+                
+                // 현재 사용자가 북마크했는지 확인
+                boolean isBookmarked = post.getBookmarks().stream()
+                    .anyMatch(bookmark -> bookmark.getMember().getMemberId().equals(memberId) && bookmark.getActivated());
+                postMap.put("isBookmarked", isBookmarked);
+                
+                // 챌린지 달성 여부
+                postMap.put("challengeAchieved", post.getChallenge() != null);
+                
+                // 작성자 정보
+                Member writer = post.getMember();
+                postMap.put("writerNickname", writer.getNickname());
+                postMap.put("writerTitle", writer.getEquippedTitle() != null ? writer.getEquippedTitle().getName() : null);
+                postMap.put("writerLevel", writer.getLevel());
+                postMap.put("writerProfileImage", writer.getProfileImage());
+                
+                return postMap;
+            })
+            .toList();
+    }
+
+    // 내가 북마크한 게시글 목록 조회 (마이페이지용)
+    @Override
+    @Transactional(readOnly = true)
+    public List<Map<String, Object>> getBookmarkedPosts(Long memberId) {
+        List<CommunityBookmark> bookmarks = bookmarkRepository.findByMember_MemberIdAndActivatedTrue(memberId);
+        
+        return bookmarks.stream()
+            .map(bookmark -> {
+                CommunityPost post = bookmark.getPost();
+                Map<String, Object> postMap = new HashMap<>();
+                postMap.put("postId", post.getPostId());
+                postMap.put("title", post.getTitle());
+                return postMap;
+            })
+            .toList();
     }
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
@@ -450,8 +450,44 @@ public class CommunityServiceImpl implements CommunityService {
             .map(bookmark -> {
                 CommunityPost post = bookmark.getPost();
                 Map<String, Object> postMap = new HashMap<>();
-                postMap.put("postId", post.getPostId());
+                postMap.put("postid", post.getPostId());
+                postMap.put("memberId", post.getMember().getMemberId());
+                postMap.put("category", post.getCategory().toString());
+                postMap.put("challengeCategory", post.getChallenge() != null ? post.getChallenge().toString() : null);
                 postMap.put("title", post.getTitle());
+                postMap.put("createdAt", post.getCreatedAt().toString());
+                postMap.put("content", post.getContent());
+                
+                // 이미지 URL 목록
+                List<String> imageUrls = post.getImages().stream()
+                    .filter(image -> image.getActivated())
+                    .map(image -> image.getImageUrl())
+                    .toList();
+                postMap.put("imageUrls", imageUrls);
+                
+                postMap.put("commentCount", post.getCommentCount());
+                postMap.put("likeCount", post.getLikeCount());
+                
+                // 현재 사용자가 좋아요를 눌렀는지 확인
+                boolean isLiked = post.getLiked().stream()
+                    .anyMatch(like -> like.getMember().getMemberId().equals(memberId) && like.getActivated());
+                postMap.put("isLiked", isLiked);
+                
+                // 북마크 여부 (명세서에 맞게 실제 북마크 상태 반영)
+                boolean isBookmarked = post.getBookmarks().stream()
+                    .anyMatch(b -> b.getMember().getMemberId().equals(memberId) && b.getActivated());
+                postMap.put("isBookmarked", isBookmarked);
+                
+                // 챌린지 달성 여부
+                postMap.put("challengeAchieved", post.getChallenge() != null);
+                
+                // 작성자 정보
+                Member writer = post.getMember();
+                postMap.put("writerNickname", writer.getNickname());
+                postMap.put("writerTitle", writer.getEquippedTitle() != null ? writer.getEquippedTitle().getName() : null);
+                postMap.put("writerLevel", writer.getLevel());
+                postMap.put("writerProfileImage", writer.getProfileImage());
+                
                 return postMap;
             })
             .toList();

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
@@ -27,7 +27,9 @@ import com.grepp.spring.infra.error.exceptions.BadRequestException;
 import com.grepp.spring.infra.payload.PageParam;
 import com.grepp.spring.util.NotFoundException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -384,5 +386,38 @@ public class CommunityServiceImpl implements CommunityService {
     private CommunityComment getActivatedComment(Long commentId) {
         return commentRepository.findByCommentIdAndActivatedTrue(commentId)
             .orElseThrow(() -> new NotFoundException("존재하지 않거나 이미 삭제된 댓글입니다."));
+    }
+
+    // 내가 작성한 게시글 목록 조회 (마이페이지용)
+    @Override
+    @Transactional(readOnly = true)
+    public List<Map<String, Object>> getMyPosts(Long memberId) {
+        List<CommunityPost> posts = communityRepository.findByMember_MemberIdAndActivatedIsTrue(memberId);
+        
+        return posts.stream()
+            .map(post -> {
+                Map<String, Object> postMap = new HashMap<>();
+                postMap.put("postId", post.getPostId());
+                postMap.put("title", post.getTitle());
+                return postMap;
+            })
+            .toList();
+    }
+
+    // 내가 북마크한 게시글 목록 조회 (마이페이지용)
+    @Override
+    @Transactional(readOnly = true)
+    public List<Map<String, Object>> getBookmarkedPosts(Long memberId) {
+        List<CommunityBookmark> bookmarks = bookmarkRepository.findByMember_MemberIdAndActivatedTrue(memberId);
+        
+        return bookmarks.stream()
+            .map(bookmark -> {
+                CommunityPost post = bookmark.getPost();
+                Map<String, Object> postMap = new HashMap<>();
+                postMap.put("postId", post.getPostId());
+                postMap.put("title", post.getTitle());
+                return postMap;
+            })
+            .toList();
     }
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/community/service/CommunityServiceImpl.java
@@ -27,9 +27,7 @@ import com.grepp.spring.infra.error.exceptions.BadRequestException;
 import com.grepp.spring.infra.payload.PageParam;
 import com.grepp.spring.util.NotFoundException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -386,38 +384,5 @@ public class CommunityServiceImpl implements CommunityService {
     private CommunityComment getActivatedComment(Long commentId) {
         return commentRepository.findByCommentIdAndActivatedTrue(commentId)
             .orElseThrow(() -> new NotFoundException("존재하지 않거나 이미 삭제된 댓글입니다."));
-    }
-
-    // 내가 작성한 게시글 목록 조회 (마이페이지용)
-    @Override
-    @Transactional(readOnly = true)
-    public List<Map<String, Object>> getMyPosts(Long memberId) {
-        List<CommunityPost> posts = communityRepository.findByMember_MemberIdAndActivatedIsTrue(memberId);
-        
-        return posts.stream()
-            .map(post -> {
-                Map<String, Object> postMap = new HashMap<>();
-                postMap.put("postId", post.getPostId());
-                postMap.put("title", post.getTitle());
-                return postMap;
-            })
-            .toList();
-    }
-
-    // 내가 북마크한 게시글 목록 조회 (마이페이지용)
-    @Override
-    @Transactional(readOnly = true)
-    public List<Map<String, Object>> getBookmarkedPosts(Long memberId) {
-        List<CommunityBookmark> bookmarks = bookmarkRepository.findByMember_MemberIdAndActivatedTrue(memberId);
-        
-        return bookmarks.stream()
-            .map(bookmark -> {
-                CommunityPost post = bookmark.getPost();
-                Map<String, Object> postMap = new HashMap<>();
-                postMap.put("postId", post.getPostId());
-                postMap.put("title", post.getTitle());
-                return postMap;
-            })
-            .toList();
     }
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/festival/domain/Festival.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/festival/domain/Festival.java
@@ -1,17 +1,13 @@
 package com.grepp.spring.app.model.festival.domain;
 
-import com.grepp.spring.app.model.place_bookmark.domain.PlaceBookmark;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -64,8 +60,5 @@ public class Festival {
 
     @Column
     private LocalDate endAt;
-
-    @OneToMany(mappedBy = "festival")
-    private Set<PlaceBookmark> placeBookmarks = new HashSet<>();
 
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/invite_code/domain/InviteCode.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/invite_code/domain/InviteCode.java
@@ -1,0 +1,56 @@
+package com.grepp.spring.app.model.invite_code.domain;
+
+import com.grepp.spring.app.model.member.domain.Member;
+import com.grepp.spring.infra.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InviteCode extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Long inviteCodeId;
+
+    @Column(nullable = false, unique = true, length = 20)
+    private String code;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creator_id", nullable = false)
+    private Member creator;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false)
+    private Boolean used = false;
+
+    // 초대코드가 만료되었는지 확인
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    // 초대코드가 유효한지 확인 (만료되지 않았고 사용되지 않음)
+    public boolean isValid() {
+        return !isExpired() && !used;
+    }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/invite_code/repos/InviteCodeRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/invite_code/repos/InviteCodeRepository.java
@@ -1,0 +1,26 @@
+package com.grepp.spring.app.model.invite_code.repos;
+
+import com.grepp.spring.app.model.invite_code.domain.InviteCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+public interface InviteCodeRepository extends JpaRepository<InviteCode, Long> {
+
+    // 코드로 초대코드 조회
+    Optional<InviteCode> findByCode(String code);
+
+    // 만료된 초대코드들 삭제
+    @Modifying
+    @Query("DELETE FROM InviteCode ic WHERE ic.expiresAt < :now")
+    void deleteExpiredCodes(@Param("now") LocalDateTime now);
+
+    // 특정 사용자가 생성한 유효한 초대코드가 있는지 확인
+    boolean existsByCreator_MemberIdAndUsedFalseAndExpiresAtAfter(Long memberId, LocalDateTime now);
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/invite_code/service/InviteCodeService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/invite_code/service/InviteCodeService.java
@@ -63,6 +63,11 @@ public class InviteCodeService {
         return code;
     }
 
+    // 초대코드 생성 (generateInviteCode 메서드 추가)
+    public String generateInviteCode(Long memberId) {
+        return createInviteCode(memberId);
+    }
+
     // 초대코드 유효성 검사
     @Transactional(readOnly = true)
     public boolean isValidInviteCode(String code) {

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/invite_code/service/InviteCodeService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/invite_code/service/InviteCodeService.java
@@ -1,0 +1,93 @@
+package com.grepp.spring.app.model.invite_code.service;
+
+import com.grepp.spring.app.model.invite_code.domain.InviteCode;
+import com.grepp.spring.app.model.invite_code.repos.InviteCodeRepository;
+import com.grepp.spring.app.model.member.domain.Member;
+import com.grepp.spring.app.model.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class InviteCodeService {
+
+    private final InviteCodeRepository inviteCodeRepository;
+    private final MemberService memberService;
+
+    // 랜덤 초대코드 생성 (8자리 영문+숫자)
+    private String generateRandomCode() {
+        String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        Random random = new Random();
+        StringBuilder code = new StringBuilder();
+        
+        for (int i = 0; i < 8; i++) {
+            code.append(chars.charAt(random.nextInt(chars.length())));
+        }
+        
+        return code.toString();
+    }
+
+    // 초대코드 생성
+    public String createInviteCode(Long memberId) {
+        // 기존 유효한 초대코드가 있는지 확인
+        if (inviteCodeRepository.existsByCreator_MemberIdAndUsedFalseAndExpiresAtAfter(memberId, LocalDateTime.now())) {
+            throw new IllegalStateException("이미 유효한 초대코드가 존재합니다.");
+        }
+
+        // 만료된 초대코드들 정리
+        inviteCodeRepository.deleteExpiredCodes(LocalDateTime.now());
+
+        // 새로운 초대코드 생성
+        String code;
+        do {
+            code = generateRandomCode();
+        } while (inviteCodeRepository.findByCode(code).isPresent());
+
+        Member creator = memberService.getMemberById(memberId);
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(10); // 10분 후 만료
+
+        InviteCode inviteCode = InviteCode.builder()
+                .code(code)
+                .creator(creator)
+                .expiresAt(expiresAt)
+                .used(false)
+                .build();
+
+        inviteCodeRepository.save(inviteCode);
+        return code;
+    }
+
+    // 초대코드 유효성 검사
+    @Transactional(readOnly = true)
+    public boolean isValidInviteCode(String code) {
+        Optional<InviteCode> inviteCodeOpt = inviteCodeRepository.findByCode(code);
+        return inviteCodeOpt.map(InviteCode::isValid).orElse(false);
+    }
+
+    // 초대코드 사용 처리
+    public void useInviteCode(String code) {
+        Optional<InviteCode> inviteCodeOpt = inviteCodeRepository.findByCode(code);
+        if (inviteCodeOpt.isPresent()) {
+            InviteCode inviteCode = inviteCodeOpt.get();
+            if (inviteCode.isValid()) {
+                inviteCode.setUsed(true);
+                inviteCodeRepository.save(inviteCode);
+            } else {
+                throw new IllegalStateException("유효하지 않은 초대코드입니다.");
+            }
+        } else {
+            throw new IllegalStateException("존재하지 않는 초대코드입니다.");
+        }
+    }
+
+    // 만료된 초대코드 정리
+    public void cleanupExpiredCodes() {
+        inviteCodeRepository.deleteExpiredCodes(LocalDateTime.now());
+    }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/library/domain/Library.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/library/domain/Library.java
@@ -1,16 +1,12 @@
 package com.grepp.spring.app.model.library.domain;
 
-import com.grepp.spring.app.model.place_bookmark.domain.PlaceBookmark;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -54,8 +50,5 @@ public class Library {
 
     @Column
     private String contact;
-
-    @OneToMany(mappedBy = "library")
-    private Set<PlaceBookmark> placeBookmarks = new HashSet<>();
 
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/domain/Member.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/domain/Member.java
@@ -7,6 +7,7 @@ import com.grepp.spring.app.model.challenge_count.domain.ChallengeCount;
 import com.grepp.spring.app.model.community.domain.CommunityPost;
 import com.grepp.spring.app.model.notification.domain.Notification;
 import com.grepp.spring.app.model.place_bookmark.domain.PlaceBookmark;
+import com.grepp.spring.infra.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -18,7 +19,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.Getter;
@@ -28,7 +28,7 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
     @Column(nullable = false, updatable = false)
@@ -58,15 +58,6 @@ public class Member {
 
     @Column
     private String phoneNumber;
-
-    @Column
-    private Boolean activated;
-
-    @Column
-    private LocalDateTime createdAt;
-
-    @Column
-    private LocalDateTime modifiedAt;
 
     @Column(nullable = false)
     private String nickname;

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
@@ -227,4 +227,13 @@ public class MemberService {
         
         memberRepository.save(member);
     }
+
+    public void withdrawMember(Long memberId) {
+        Member member = getMemberById(memberId);
+        
+        // 회원 탈퇴 처리 (activated = false)
+        member.setActivated(false);
+        
+        memberRepository.save(member);
+    }
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
@@ -190,8 +190,9 @@ public class MemberService {
             referencedWarning.addParam(memberAttendance.getAttendanceId());
             return referencedWarning;
         }
-        final Budget memberBudget = budgetRepository.findFirstByMember(member);
-        if (memberBudget != null) {
+        final java.util.Optional<Budget> memberBudgetOpt = budgetRepository.findFirstByMember(member);
+        if (memberBudgetOpt.isPresent()) {
+            Budget memberBudget = memberBudgetOpt.get();
             referencedWarning.setKey("member.budget.member.referenced");
             referencedWarning.addParam(memberBudget.getBudgetId());
             return referencedWarning;

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
@@ -190,9 +190,8 @@ public class MemberService {
             referencedWarning.addParam(memberAttendance.getAttendanceId());
             return referencedWarning;
         }
-        final java.util.Optional<Budget> memberBudgetOpt = budgetRepository.findFirstByMember(member);
-        if (memberBudgetOpt.isPresent()) {
-            Budget memberBudget = memberBudgetOpt.get();
+        final Budget memberBudget = budgetRepository.findFirstByMember(member);
+        if (memberBudget != null) {
             referencedWarning.setKey("member.budget.member.referenced");
             referencedWarning.addParam(memberBudget.getBudgetId());
             return referencedWarning;

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/service/MemberService.java
@@ -210,4 +210,21 @@ public class MemberService {
         return memberRepository.findById(memberId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
     }
+
+    public void updateProfile(Long memberId, com.grepp.spring.app.controller.api.member.MemberController.ProfileUpdateRequest request) {
+        Member member = getMemberById(memberId);
+        
+        // 닉네임 업데이트 (입력된 경우)
+        if (request.getNickname() != null && !request.getNickname().isBlank()) {
+            member.setNickname(request.getNickname());
+        }
+        
+        // 비밀번호 업데이트 (입력된 경우)
+        if (request.getNewPassword() != null && !request.getNewPassword().isBlank()) {
+            // 비밀번호 암호화는 컨트롤러에서 처리하므로 여기서는 그대로 설정
+            member.setPassword(request.getNewPassword());
+        }
+        
+        memberRepository.save(member);
+    }
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/domain/Notification.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/domain/Notification.java
@@ -1,6 +1,7 @@
 package com.grepp.spring.app.model.notification.domain;
 
 import com.grepp.spring.app.model.member.domain.Member;
+import com.grepp.spring.infra.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,7 +11,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
-import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -18,7 +18,7 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
-public class Notification {
+public class Notification extends BaseEntity {
 
     @Id
     @Column(nullable = false, updatable = false)
@@ -49,15 +49,6 @@ public class Notification {
 
     @Column(length = 255)
     private String type; // 알림타입
-
-    @Column
-    private LocalDateTime createdAt;
-
-    @Column
-    private LocalDateTime modifiedAt;
-
-    @Column
-    private Boolean activated;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "memberId", nullable = false)

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/place_bookmark/domain/PlaceBookmark.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/place_bookmark/domain/PlaceBookmark.java
@@ -4,6 +4,7 @@ import com.grepp.spring.app.model.festival.domain.Festival;
 import com.grepp.spring.app.model.library.domain.Library;
 import com.grepp.spring.app.model.member.domain.Member;
 import com.grepp.spring.app.model.store.domain.Store;
+import com.grepp.spring.infra.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -13,7 +14,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
-import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -21,18 +21,12 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
-public class PlaceBookmark {
+public class PlaceBookmark extends BaseEntity {
 
     @Id
     @Column(nullable = false, updatable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long pBookmarkId;
-
-    @Column
-    private LocalDateTime createdAt;
-
-    @Column
-    private Boolean activatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "memberId", nullable = false)

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/place_bookmark/repos/PlaceBookmarkRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/place_bookmark/repos/PlaceBookmarkRepository.java
@@ -6,6 +6,11 @@ import com.grepp.spring.app.model.member.domain.Member;
 import com.grepp.spring.app.model.place_bookmark.domain.PlaceBookmark;
 import com.grepp.spring.app.model.store.domain.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 
 public interface PlaceBookmarkRepository extends JpaRepository<PlaceBookmark, Long> {
@@ -18,4 +23,24 @@ public interface PlaceBookmarkRepository extends JpaRepository<PlaceBookmark, Lo
 
     PlaceBookmark findFirstByLibrary(Library library);
 
+    // 멤버별 활성화된 장소 북마크 목록 조회
+    List<PlaceBookmark> findByMemberAndActivatedAtTrue(Member member);
+
+    // 특정 멤버의 특정 스토어 북마크 조회
+    Optional<PlaceBookmark> findByMemberAndStore(Member member, Store store);
+
+    // 특정 멤버의 특정 페스티벌 북마크 조회
+    Optional<PlaceBookmark> findByMemberAndFestival(Member member, Festival festival);
+
+    // 특정 멤버의 특정 도서관 북마크 조회
+    Optional<PlaceBookmark> findByMemberAndLibrary(Member member, Library library);
+
+    // 특정 멤버의 특정 스토어 북마크 존재 여부 확인
+    boolean existsByMemberAndStore(Member member, Store store);
+
+    // 특정 멤버의 특정 페스티벌 북마크 존재 여부 확인
+    boolean existsByMemberAndFestival(Member member, Festival festival);
+
+    // 특정 멤버의 특정 도서관 북마크 존재 여부 확인
+    boolean existsByMemberAndLibrary(Member member, Library library);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/place_bookmark/repos/PlaceBookmarkRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/place_bookmark/repos/PlaceBookmarkRepository.java
@@ -24,7 +24,7 @@ public interface PlaceBookmarkRepository extends JpaRepository<PlaceBookmark, Lo
     PlaceBookmark findFirstByLibrary(Library library);
 
     // 멤버별 활성화된 장소 북마크 목록 조회
-    List<PlaceBookmark> findByMemberAndActivatedAtTrue(Member member);
+    List<PlaceBookmark> findByMemberAndActivatedTrue(Member member);
 
     // 특정 멤버의 특정 스토어 북마크 조회
     Optional<PlaceBookmark> findByMemberAndStore(Member member, Store store);

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/place_bookmark/service/PlaceBookmarkService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/place_bookmark/service/PlaceBookmarkService.java
@@ -74,7 +74,7 @@ public class PlaceBookmarkService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundException("멤버를 찾을 수 없습니다."));
 
-        List<PlaceBookmark> bookmarks = placeBookmarkRepository.findByMemberAndActivatedAtTrue(member);
+        List<PlaceBookmark> bookmarks = placeBookmarkRepository.findByMemberAndActivatedTrue(member);
         
         return bookmarks.stream()
                 .map(this::convertToResponseMap)
@@ -111,7 +111,7 @@ public class PlaceBookmarkService {
         }
 
         // 북마크 비활성화 (삭제 대신 비활성화)
-        bookmark.setActivatedAt(false);
+        bookmark.setActivated(false);
         placeBookmarkRepository.save(bookmark);
     }
 
@@ -164,7 +164,7 @@ public class PlaceBookmarkService {
             final PlaceBookmarkDTO placeBookmarkDTO) {
         placeBookmarkDTO.setPBookmarkId(placeBookmark.getPBookmarkId());
         placeBookmarkDTO.setCreatedAt(placeBookmark.getCreatedAt());
-        placeBookmarkDTO.setActivatedAt(placeBookmark.getActivatedAt());
+        placeBookmarkDTO.setActivatedAt(placeBookmark.getActivated());
         placeBookmarkDTO.setMember(placeBookmark.getMember() == null ? null : placeBookmark.getMember().getMemberId());
         placeBookmarkDTO.setFestival(placeBookmark.getFestival() == null ? null : placeBookmark.getFestival().getFestivalId());
         placeBookmarkDTO.setStore(placeBookmark.getStore() == null ? null : placeBookmark.getStore().getStoreId());
@@ -175,7 +175,7 @@ public class PlaceBookmarkService {
     private PlaceBookmark mapToEntity(final PlaceBookmarkDTO placeBookmarkDTO,
             final PlaceBookmark placeBookmark) {
         placeBookmark.setCreatedAt(placeBookmarkDTO.getCreatedAt());
-        placeBookmark.setActivatedAt(placeBookmarkDTO.getActivatedAt());
+        placeBookmark.setActivated(placeBookmarkDTO.getActivatedAt());
         final Member member = placeBookmarkDTO.getMember() == null ? null : memberRepository.findById(placeBookmarkDTO.getMember())
                 .orElseThrow(() -> new NotFoundException("member not found"));
         placeBookmark.setMember(member);

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/place_bookmark/service/PlaceBookmarkService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/place_bookmark/service/PlaceBookmarkService.java
@@ -13,6 +13,9 @@ import com.grepp.spring.app.model.store.domain.Store;
 import com.grepp.spring.app.model.store.repos.StoreRepository;
 import com.grepp.spring.util.NotFoundException;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Optional;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
@@ -64,6 +67,97 @@ public class PlaceBookmarkService {
 
     public void delete(final Long pBookmarkId) {
         placeBookmarkRepository.deleteById(pBookmarkId);
+    }
+
+    // 멤버별 장소 북마크 목록 조회
+    public List<Map<String, Object>> getMemberPlaceBookmarks(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException("멤버를 찾을 수 없습니다."));
+
+        List<PlaceBookmark> bookmarks = placeBookmarkRepository.findByMemberAndActivatedAtTrue(member);
+        
+        return bookmarks.stream()
+                .map(this::convertToResponseMap)
+                .toList();
+    }
+
+    // 장소 북마크 해제
+    public void unbookmarkPlace(Long memberId, Long placeId, String placeType) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException("멤버를 찾을 수 없습니다."));
+
+        PlaceBookmark bookmark = null;
+
+        switch (placeType.toLowerCase()) {
+            case "store" -> {
+                Store store = storeRepository.findById(placeId)
+                        .orElseThrow(() -> new NotFoundException("스토어를 찾을 수 없습니다."));
+                bookmark = placeBookmarkRepository.findByMemberAndStore(member, store)
+                        .orElseThrow(() -> new NotFoundException("북마크를 찾을 수 없습니다."));
+            }
+            case "festival" -> {
+                Festival festival = festivalRepository.findById(placeId)
+                        .orElseThrow(() -> new NotFoundException("페스티벌을 찾을 수 없습니다."));
+                bookmark = placeBookmarkRepository.findByMemberAndFestival(member, festival)
+                        .orElseThrow(() -> new NotFoundException("북마크를 찾을 수 없습니다."));
+            }
+            case "library" -> {
+                Library library = libraryRepository.findById(placeId)
+                        .orElseThrow(() -> new NotFoundException("도서관을 찾을 수 없습니다."));
+                bookmark = placeBookmarkRepository.findByMemberAndLibrary(member, library)
+                        .orElseThrow(() -> new NotFoundException("북마크를 찾을 수 없습니다."));
+            }
+            default -> throw new IllegalArgumentException("지원하지 않는 장소 타입입니다: " + placeType);
+        }
+
+        // 북마크 비활성화 (삭제 대신 비활성화)
+        bookmark.setActivatedAt(false);
+        placeBookmarkRepository.save(bookmark);
+    }
+
+    // PlaceBookmark를 응답용 Map으로 변환
+    private Map<String, Object> convertToResponseMap(PlaceBookmark bookmark) {
+        Map<String, Object> result = new HashMap<>();
+        
+        // placeId는 pBookmarkId 사용
+        result.put("placeId", bookmark.getPBookmarkId().toString());
+        result.put("bookmarkedAt", bookmark.getCreatedAt());
+
+        if (bookmark.getStore() != null) {
+            Store store = bookmark.getStore();
+            result.put("storeId", store.getStoreId().toString());
+            result.put("name", store.getName());
+            result.put("address", store.getAddress());
+            result.put("category", store.getCategory());
+            result.put("type", "store");
+            result.put("contact", store.getContact());
+            result.put("firstmenu", store.getFirstMenu());
+            result.put("firstprice", store.getFirstPrice());
+            result.put("secondmenu", store.getSecondMenu());
+            result.put("secondprice", store.getSecondPrice());
+            result.put("thirdmenu", store.getThirdMenu());
+            result.put("thirdprice", store.getThirdPrice());
+        } else if (bookmark.getFestival() != null) {
+            Festival festival = bookmark.getFestival();
+            result.put("festivalId", festival.getFestivalId().toString());
+            result.put("name", festival.getName());
+            result.put("category", festival.getCategory());
+            result.put("type", "festival");
+            result.put("address", festival.getAddress());
+            result.put("target", festival.getTarget());
+            result.put("url", festival.getUrl());
+            result.put("startAt", festival.getStartAt());
+            result.put("endAt", festival.getEndAt());
+        } else if (bookmark.getLibrary() != null) {
+            Library library = bookmark.getLibrary();
+            result.put("libraryId", library.getLibraryId().toString());
+            result.put("name", library.getName());
+            result.put("type", "library");
+            result.put("address", library.getAddress());
+            result.put("url", library.getUrl());
+        }
+
+        return result;
     }
 
     private PlaceBookmarkDTO mapToDTO(final PlaceBookmark placeBookmark,

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/store/domain/Store.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/store/domain/Store.java
@@ -1,11 +1,8 @@
 package com.grepp.spring.app.model.store.domain;
 
-import com.grepp.spring.app.model.place_bookmark.domain.PlaceBookmark;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -71,8 +68,5 @@ public class Store {
 
     @Column
     private String sido;
-
-    @OneToMany(mappedBy = "store")
-    private Set<PlaceBookmark> placeBookmarks = new HashSet<>();
 
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/entity/BaseEntity.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/entity/BaseEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -12,6 +13,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 @Getter
+@Setter
 public class BaseEntity {
     
     protected Boolean activated = true;


### PR DESCRIPTION
## 주요 변경사항

**마이페이지 기능 구현**
- 마이페이지 조회 API 구현
- 마이페이지 프로필 수정 API 구현
- 목표 설정/조회 API 구현
- 마이페이지 목표 달성률 계산 로직 구현 및 Decimal 타입을 BigDecimal로 변경

**칭호 시스템**
- 칭호 관련 API 구현

**커뮤니티 기능**
- 내가 작성한 게시글 조회 API 구현

**장소 관리**
- 장소 북마크 조회/해제 API 구현

**회원 관리 기능**
- 회원 탈퇴 API 구현
- 초대코드 생성 및 회원가입 시 초대코드 입력 기능 구현

## 기술적 개선
- 타입 안정성: Decimal 타입을 BigDecimal로 변경하여 금융 데이터의 정확한 계산 보장