### PR TITLE
Feature: 챌린지 전체조회, 만원의 행복 챌린지

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/budgetdetail/BudgetDetailController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/budgetdetail/BudgetDetailController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.parameters.P;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -79,9 +80,9 @@ public class BudgetDetailController {
 
     @Operation(summary = "날짜별 내역 삭제")
     @DeleteMapping("/detail/{detail_id}")
-    public ApiResponse<?> deleteBudgetDetail(@PathVariable("detail_id") Long id) {
+    public ApiResponse<?> deleteBudgetDetail(@AuthenticationPrincipal Principal principal, @PathVariable("detail_id") Long id) {
 
-        budgetDetailService.deleteBudgetDetail(id);
+        budgetDetailService.deleteBudgetDetail(principal.getMemberId(),id);
         return new ApiResponse<>("2000", "내역삭제되었습니다", null);
     }
 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/challengeController/ChallengeController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/challengeController/ChallengeController.java
@@ -1,0 +1,30 @@
+package com.grepp.spring.app.controller.api.challengeController;
+
+
+import com.grepp.spring.app.model.auth.domain.Principal;
+import com.grepp.spring.app.model.challenge.model.ChallengeStatusDto;
+import com.grepp.spring.app.model.challenge.service.ChallengeService;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/challenge")
+public class ChallengeController {
+
+    private final ChallengeService challengeService;
+
+    @GetMapping
+    public List<ChallengeStatusDto> get(@AuthenticationPrincipal Principal principal) {
+
+        List<ChallengeStatusDto> challengeStatuses = challengeService.getChallengeStatuses(
+            principal.getMemberId());
+        return challengeStatuses;
+    }
+
+}

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/domain/Challenge.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/domain/Challenge.java
@@ -20,18 +20,8 @@ import lombok.Setter;
 @Setter
 public class Challenge {
 
-    @Id
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(nullable = false, updatable = false)
-    @SequenceGenerator(
-            name = "primary_sequence",
-            sequenceName = "primary_sequence",
-            allocationSize = 1,
-            initialValue = 10000
-    )
-    @GeneratedValue(
-            strategy = GenerationType.SEQUENCE,
-            generator = "primary_sequence"
-    )
     private Long challengeId;
 
     @Column(nullable = false)
@@ -45,6 +35,13 @@ public class Challenge {
 
     @Column
     private Integer exp;
+
+    @Column
+    private String icon;
+
+    @Column
+    private Integer total;
+
 
     @OneToMany(mappedBy = "challenge")
     private Set<ChallengeCount> challengeCounts = new HashSet<>();

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/model/ChallengeStatusDto.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/model/ChallengeStatusDto.java
@@ -1,0 +1,24 @@
+package com.grepp.spring.app.model.challenge.model;
+
+import com.grepp.spring.app.model.challenge.domain.Challenge;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChallengeStatusDto {
+
+    private Long challengeId;
+    private String name;
+    private String description;
+    private String type;
+    private int total;
+    private int progress;
+    private String icon;
+}

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/repos/ChallengeRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/repos/ChallengeRepository.java
@@ -1,8 +1,40 @@
 package com.grepp.spring.app.model.challenge.repos;
 
 import com.grepp.spring.app.model.challenge.domain.Challenge;
+import com.grepp.spring.app.model.challenge.model.ChallengeStatusDto;
+import feign.Param;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+
+
+    @Query("""
+    SELECT new com.grepp.spring.app.model.challenge.model.ChallengeStatusDto(
+        c.challengeId,
+        c.name,
+        c.description,
+        c.type,
+        c.total,
+        COALESCE(cc.count, 0),
+        c.icon
+    )
+    FROM Challenge c
+    LEFT JOIN ChallengeCount cc ON cc.challenge = c AND cc.member.memberId = :memberId
+        AND (
+            (c.type = '일일' AND FUNCTION('DATE', cc.createdAt) = :today)
+            OR (c.type = '월간' AND FUNCTION('TO_CHAR', cc.createdAt, 'YYYY-MM') = :currentMonth)
+            OR (c.type = '커뮤니티')
+        )
+    ORDER BY c.challengeId
+""")
+    List<ChallengeStatusDto> findWithCount(@Param("memberId") Long memberId,
+        @Param("today") LocalDate today,
+        @Param("currentMonth") String currentMonth);
+
+    Optional<Challenge> findByname(String name);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/service/ChallengeService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/service/ChallengeService.java
@@ -1,98 +1,27 @@
 package com.grepp.spring.app.model.challenge.service;
 
-import com.grepp.spring.app.model.achieved_title.domain.AchievedTitle;
-import com.grepp.spring.app.model.achieved_title.repos.AchievedTitleRepository;
-import com.grepp.spring.app.model.challenge.domain.Challenge;
-import com.grepp.spring.app.model.challenge.model.ChallengeDTO;
-import com.grepp.spring.app.model.challenge.repos.ChallengeRepository;
-import com.grepp.spring.app.model.challenge_count.domain.ChallengeCount;
-import com.grepp.spring.app.model.challenge_count.repos.ChallengeCountRepository;
-import com.grepp.spring.util.NotFoundException;
-import com.grepp.spring.util.ReferencedWarning;
-import java.util.List;
-import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Service;
 
+import com.grepp.spring.app.model.challenge.domain.Challenge;
+import com.grepp.spring.app.model.challenge.model.ChallengeStatusDto;
+import com.grepp.spring.app.model.challenge.repos.ChallengeRepository;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class ChallengeService {
 
     private final ChallengeRepository challengeRepository;
-    private final ChallengeCountRepository challengeCountRepository;
-    private final AchievedTitleRepository achievedTitleRepository;
 
-    public ChallengeService(final ChallengeRepository challengeRepository,
-            final ChallengeCountRepository challengeCountRepository,
-            final AchievedTitleRepository achievedTitleRepository) {
-        this.challengeRepository = challengeRepository;
-        this.challengeCountRepository = challengeCountRepository;
-        this.achievedTitleRepository = achievedTitleRepository;
+    @Transactional(readOnly = true)
+    public List<ChallengeStatusDto> getChallengeStatuses(Long memberId) {
+        LocalDate today = LocalDate.now();
+        String currentMonth = YearMonth.now().toString(); // ex: "2025-07"
+
+        return challengeRepository.findWithCount(memberId, today, currentMonth);
     }
-
-    public List<ChallengeDTO> findAll() {
-        final List<Challenge> challenges = challengeRepository.findAll(Sort.by("challengeId"));
-        return challenges.stream()
-                .map(challenge -> mapToDTO(challenge, new ChallengeDTO()))
-                .toList();
-    }
-
-    public ChallengeDTO get(final Long challengeId) {
-        return challengeRepository.findById(challengeId)
-                .map(challenge -> mapToDTO(challenge, new ChallengeDTO()))
-                .orElseThrow(NotFoundException::new);
-    }
-
-    public Long create(final ChallengeDTO challengeDTO) {
-        final Challenge challenge = new Challenge();
-        mapToEntity(challengeDTO, challenge);
-        return challengeRepository.save(challenge).getChallengeId();
-    }
-
-    public void update(final Long challengeId, final ChallengeDTO challengeDTO) {
-        final Challenge challenge = challengeRepository.findById(challengeId)
-                .orElseThrow(NotFoundException::new);
-        mapToEntity(challengeDTO, challenge);
-        challengeRepository.save(challenge);
-    }
-
-    public void delete(final Long challengeId) {
-        challengeRepository.deleteById(challengeId);
-    }
-
-    private ChallengeDTO mapToDTO(final Challenge challenge, final ChallengeDTO challengeDTO) {
-        challengeDTO.setChallengeId(challenge.getChallengeId());
-        challengeDTO.setName(challenge.getName());
-        challengeDTO.setDescription(challenge.getDescription());
-        challengeDTO.setType(challenge.getType());
-        challengeDTO.setExp(challenge.getExp());
-        return challengeDTO;
-    }
-
-    private Challenge mapToEntity(final ChallengeDTO challengeDTO, final Challenge challenge) {
-        challenge.setName(challengeDTO.getName());
-        challenge.setDescription(challengeDTO.getDescription());
-        challenge.setType(challengeDTO.getType());
-        challenge.setExp(challengeDTO.getExp());
-        return challenge;
-    }
-
-    public ReferencedWarning getReferencedWarning(final Long challengeId) {
-        final ReferencedWarning referencedWarning = new ReferencedWarning();
-        final Challenge challenge = challengeRepository.findById(challengeId)
-                .orElseThrow(NotFoundException::new);
-        final ChallengeCount challengeChallengeCount = challengeCountRepository.findFirstByChallenge(challenge);
-        if (challengeChallengeCount != null) {
-            referencedWarning.setKey("challenge.challengeCount.challenge.referenced");
-            referencedWarning.addParam(challengeChallengeCount.getChallengeCountId());
-            return referencedWarning;
-        }
-        final AchievedTitle challengeAchievedTitle = achievedTitleRepository.findFirstByChallenge(challenge);
-        if (challengeAchievedTitle != null) {
-            referencedWarning.setKey("challenge.achievedTitle.challenge.referenced");
-            referencedWarning.addParam(challengeAchievedTitle.getATId());
-            return referencedWarning;
-        }
-        return null;
-    }
-
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge_count/domain/ChallengeCount.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge_count/domain/ChallengeCount.java
@@ -2,6 +2,7 @@ package com.grepp.spring.app.model.challenge_count.domain;
 
 import com.grepp.spring.app.model.challenge.domain.Challenge;
 import com.grepp.spring.app.model.member.domain.Member;
+import com.grepp.spring.infra.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -18,22 +19,10 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
-public class ChallengeCount {
+public class ChallengeCount extends BaseEntity {
 
-    @Id
-    @Column(nullable = false, updatable = false)
-    @SequenceGenerator(
-            name = "primary_sequence",
-            sequenceName = "primary_sequence",
-            allocationSize = 1,
-            initialValue = 10000
-    )
-    @GeneratedValue(
-            strategy = GenerationType.SEQUENCE,
-            generator = "primary_sequence"
-    )
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long challengeCountId;
-
 
     @Column(nullable = false)
     private Integer count;

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge_count/repos/ChallengeCountRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge_count/repos/ChallengeCountRepository.java
@@ -4,6 +4,8 @@ import com.grepp.spring.app.model.challenge.domain.Challenge;
 import com.grepp.spring.app.model.challenge_count.domain.ChallengeCount;
 import com.grepp.spring.app.model.challenge_count.model.ChallengeTopResponse;
 import com.grepp.spring.app.model.member.domain.Member;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -27,4 +29,7 @@ public interface ChallengeCountRepository extends JpaRepository<ChallengeCount, 
         ORDER BY SUM(cc.count) DESC
     """)
     List<ChallengeTopResponse> findTopAchievedChallengeNames(Pageable pageable);
+
+
+    Optional<ChallengeCount> findByMemberAndChallengeAndCreatedAtBetween(Member member, Challenge challenge, LocalDateTime localDateTime, LocalDateTime localDateTime1);
 }


### PR DESCRIPTION
📋 구현 내용

1. 챌린지전체조회 (GET) /api/challenge
    전체조회할 때 15개의 챌린지 대해서 나오고 사용자의 행동에 따라 바뀌는 progress가 반영되어서 조회됩니다.
    일일챌린지는 Challenge_count테이블의 당일날짜 progress
    월별챌린지는 당일 월의 progress
    커뮤니티 챌린지는 단발성이라 날짜관련없이 지금까지의 progress가 나옵니다.

2. 만원의 행복 챌린지 budgetdetailService에 handel_under10000Challenge메서드를 추가해서 가계부내역 추가,수정,삭제시 progress가
    반영되도록 하였습니다. 

챌린지 추가
INSERT INTO challenge (challenge_id, name, type, description, exp, icon, total) VALUES
(1, '만원의 행복', '일일', '만원으로 하루 살아보기', 20, 'moneyIcon', 1),
(2, '찐 기록러', '일일', '오늘 사용한 영수증 인증하기', 20, 'receipt', 1),
(3, '소비 단식러', '일일', '하루 식비 0원 달성', 20, 'zeroFood', 1),
(4, '강철 다리', '일일', '하루 교통비 0원 달성', 20, 'zeroTransition', 1),
(5, '소통왕', '월간', '댓글, 좋아요 10개', 100, 'heart', 10),
(6, '개근왕', '월간', '한 달 출석 체크', 100, 'oneMonth', 30),
(7, '인싸왕', '월간', '친구 초대 이벤트', 100, 'friend', 1),
(8, '절약왕', '월간', '지난 달 나보다 덜 쓰기', 100, 'saveMoney', 100),
(9, '기록 장인', '월간', '한달 연속으로 가계부 작성하기', 100, 'oneMonthAccount', 30),
(10, '머니 매니저', '월간', '월급 입력하기', 100, 'salary', 1),
(11, '제로 마스터', '커뮤니티', '하루 0원으로 이거까지?', 100, 'noMoney', 1),
(12, '착한 소비러', '커뮤니티', '착한 가게 방문 인증', 100, 'angel', 1),
(13, '숨.맛.탐', '커뮤니티', '나가게 글 5개 이상 작성하기', 100, 'detective', 5),
(14, '노노 카페', '커뮤니티', '노노 카페 데이', 100, 'noCafe', 1),
(15, '냉털 요리왕', '커뮤니티', '집밥 세끼', 100, 'cook', 1);