### PR TITLE
Feature: 소비단식러,강철다리 챌린지

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/budgetdetail/BudgetDetailController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/budgetdetail/BudgetDetailController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.parameters.P;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -79,9 +80,9 @@ public class BudgetDetailController {
 
     @Operation(summary = "날짜별 내역 삭제")
     @DeleteMapping("/detail/{detail_id}")
-    public ApiResponse<?> deleteBudgetDetail(@PathVariable("detail_id") Long id) {
+    public ApiResponse<?> deleteBudgetDetail(@AuthenticationPrincipal Principal principal, @PathVariable("detail_id") Long id) {
 
-        budgetDetailService.deleteBudgetDetail(id);
+        budgetDetailService.deleteBudgetDetail(principal.getMemberId(),id);
         return new ApiResponse<>("2000", "내역삭제되었습니다", null);
     }
 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/budgetdetail/BudgetDetailController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/budgetdetail/BudgetDetailController.java
@@ -72,9 +72,11 @@ public class BudgetDetailController {
 
     @Operation(summary = "날짜별 내역 수정")
     @PatchMapping("/detail/{detail_id}")
-    public ApiResponse<?> updateBudgetDetail(@PathVariable("detail_id") Long id, @RequestBody BudgetDetailRequestDTO dto) {
+    public ApiResponse<?> updateBudgetDetail(@AuthenticationPrincipal Principal principal,
+                                             @PathVariable("detail_id") Long id,
+                                             @RequestBody BudgetDetailRequestDTO dto) {
 
-        UpdatedBudgetDetailResponseDto updatedExpenseResponseDto = budgetDetailService.updateBudgetDetail(id, dto);
+        UpdatedBudgetDetailResponseDto updatedExpenseResponseDto = budgetDetailService.updateBudgetDetail(principal.getMemberId(), id, dto);
         return new ApiResponse<>("2000", "내역이 수정되었습니다.", updatedExpenseResponseDto);
     }
 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/budgetdetail/BudgetDetailController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/budgetdetail/BudgetDetailController.java
@@ -92,8 +92,7 @@ public class BudgetDetailController {
     @PostMapping("/noexpenses")
     public ApiResponse<?> noExpense(@AuthenticationPrincipal Principal principal) {
 
-        budgetDetailService.registerNoExpense(principal.getMemberId());
-        return new ApiResponse<>("2000", "지출없음으로되었습니다", null);
+        return budgetDetailService.registerNoExpense(principal.getMemberId());
     }
 
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/challengeController/ChallengeController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/challengeController/ChallengeController.java
@@ -4,6 +4,7 @@ package com.grepp.spring.app.controller.api.challengeController;
 import com.grepp.spring.app.model.auth.domain.Principal;
 import com.grepp.spring.app.model.challenge.model.ChallengeStatusDto;
 import com.grepp.spring.app.model.challenge.service.ChallengeService;
+import com.grepp.spring.infra.response.ApiResponse;
 import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -20,11 +21,11 @@ public class ChallengeController {
     private final ChallengeService challengeService;
 
     @GetMapping
-    public List<ChallengeStatusDto> get(@AuthenticationPrincipal Principal principal) {
+    public ApiResponse<List<ChallengeStatusDto>> get(@AuthenticationPrincipal Principal principal) {
 
         List<ChallengeStatusDto> challengeStatuses = challengeService.getChallengeStatuses(
             principal.getMemberId());
-        return challengeStatuses;
+        return ApiResponse.success(challengeStatuses);
     }
 
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/challengeController/ChallengeController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/challengeController/ChallengeController.java
@@ -1,0 +1,30 @@
+package com.grepp.spring.app.controller.api.challengeController;
+
+
+import com.grepp.spring.app.model.auth.domain.Principal;
+import com.grepp.spring.app.model.challenge.model.ChallengeStatusDto;
+import com.grepp.spring.app.model.challenge.service.ChallengeService;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/challenge")
+public class ChallengeController {
+
+    private final ChallengeService challengeService;
+
+    @GetMapping
+    public List<ChallengeStatusDto> get(@AuthenticationPrincipal Principal principal) {
+
+        List<ChallengeStatusDto> challengeStatuses = challengeService.getChallengeStatuses(
+            principal.getMemberId());
+        return challengeStatuses;
+    }
+
+}

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget/repos/BudgetRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget/repos/BudgetRepository.java
@@ -67,4 +67,13 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
     Optional<BigDecimal> sumTotalExpenseByMemberUntilToday(
         @Param("memberId") Long memberId,
         @Param("today") LocalDate today);
+
+    @Query("""
+    SELECT COUNT(b) > 0
+    FROM Budget b
+    WHERE b.member.memberId = :memberId
+    AND b.date = :date
+    """)
+    boolean existsBudgetByMemberIdAndDate(@Param("memberId") Long memberId,
+        @Param("date") LocalDate date);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget_detail/repos/BudgetDetailRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget_detail/repos/BudgetDetailRepository.java
@@ -68,4 +68,16 @@ public interface BudgetDetailRepository extends JpaRepository<BudgetDetail, Long
         @Param("memberId") Long memberId,
         @Param("startDate") LocalDate start,
         @Param("endDate") LocalDate end);
+
+
+    @Query("""
+    SELECT COUNT(d) > 0
+    FROM BudgetDetail d
+    WHERE d.budget.member.memberId = :memberId
+      AND d.category = :category
+      AND d.date = :date
+""")
+    boolean existsBudgetDetailByMemberAndDate(@Param("memberId") Long memberId,
+        @Param("category") String category,
+        @Param("date") LocalDate date);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget_detail/service/BudgetDetailService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget_detail/service/BudgetDetailService.java
@@ -56,16 +56,17 @@ public class BudgetDetailService {
     }
 
     @Transactional
-    public void registerBudgetDetail(String username,BudgetDetailRequestDTO dto) {
+    public void registerBudgetDetail(String username, BudgetDetailRequestDTO dto) {
 
         Member member = memberRepository.findByEmail(username)
             .orElseThrow(() -> new RuntimeException("해당 ID의 회원이 존재하지 않습니다."));
 
         // 1. 해당 날짜의 가계부(Budget) 조회
         Budget budget = budgetRepository.findByDateAndMember(LocalDate.parse(dto.getDate()), member)
-            .orElseGet(() -> budgetRepository.save(Budget.create(LocalDate.parse(dto.getDate()), member)));
+            .orElseGet(
+                () -> budgetRepository.save(Budget.create(LocalDate.parse(dto.getDate()), member)));
 
-        budget.addAmount(dto.getType(),dto.getPrice());
+        budget.addAmount(dto.getType(), dto.getPrice());
 
         // 2. 지출 세부사항(BudgetDetail) 생성
         BudgetDetail detail = BudgetDetail.builder()
@@ -80,19 +81,22 @@ public class BudgetDetailService {
 
         budgetDetailRepository.save(detail);
 
-        // 만원의행복검증
-        if(LocalDate.parse(dto.getDate()).equals(LocalDate.now()))
-        {
-            handle_under10000Challenge(member, budget, false,true);
+        //챌린지
+        if (LocalDate.parse(dto.getDate()).equals(LocalDate.now())) {
 
+            //만원의행복
+            handle_under10000Challenge(member, budget, false, true);
+
+            //소비단식러
+            handle_zerofoodChallenge(member);
 
         }
-
     }
 
-    // 지출수정
+
     @Transactional
-    public UpdatedBudgetDetailResponseDto updateBudgetDetail(Long detailId, BudgetDetailRequestDTO dto) {
+    public UpdatedBudgetDetailResponseDto updateBudgetDetail(Long memberId, Long detailId,
+        BudgetDetailRequestDTO dto) {
 
         // 1. 수정할 BudgetDetail 엔티티 조회
         BudgetDetail budgetDetail = budgetDetailRepository.findById(detailId)
@@ -115,7 +119,8 @@ public class BudgetDetailService {
             oldBudget.getBudgetDetails().remove(budgetDetail);
 
             newBudget = budgetRepository.findByDateAndMember(newDate, member)
-                .orElseGet(() -> budgetRepository.save(Budget.create(LocalDate.parse(dto.getDate()), member)));
+                .orElseGet(() -> budgetRepository.save(
+                    Budget.create(LocalDate.parse(dto.getDate()), member)));
 
             budgetDetail.setBudget(newBudget);
             empty = oldBudget.getBudgetDetails().isEmpty();
@@ -132,14 +137,14 @@ public class BudgetDetailService {
         newBudget.addAmount(dto.getType(), dto.getPrice());
 
         // 만원의 행복 챌린지 검증
-        if(LocalDate.parse(dto.getDate()).equals(LocalDate.now())){
-            handle_under10000Challenge(member, newBudget, false ,true);
-        }
-        else{
-            handle_under10000Challenge(member, oldBudget, empty ,true);
+        if (LocalDate.parse(dto.getDate()).equals(LocalDate.now())) {
+            handle_under10000Challenge(member, newBudget, false, true);
+        } else {
+            handle_under10000Challenge(member, oldBudget, empty, true);
         }
 
-
+        // 소비단식러
+        handle_zerofoodChallenge(member);
 
         return new UpdatedBudgetDetailResponseDto(
             detailId,
@@ -174,7 +179,11 @@ public class BudgetDetailService {
         }
 
         // 만원의 행복 검증
-        handle_under10000Challenge(member, budget, false ,hasOtherDetails);
+        handle_under10000Challenge(member, budget, false, hasOtherDetails);
+
+        // 소비단식러
+        handle_zerofoodChallenge(member);
+
 
     }
 
@@ -197,35 +206,49 @@ public class BudgetDetailService {
         LocalDate today = LocalDate.now();
 
         Budget budget = budgetRepository.findByMemberAndDate(member, today)
-            .orElseGet(() -> {
-                Budget newBudget = new Budget();
-                newBudget.setMember(member);
-                newBudget.setDate(today);
-                newBudget.setTotalIncome(BigDecimal.ZERO);
-                newBudget.setTotalExpense(BigDecimal.ZERO);
-                return budgetRepository.save(newBudget);
-            });
+            .orElse(null);
+
+        if (budget != null) {
+            if (budget.getTotalIncome().compareTo(BigDecimal.ZERO) == 0 &&
+                budget.getTotalExpense().compareTo(BigDecimal.ZERO) == 0) {
+                throw new RuntimeException("오늘은 이미 지출 없음 등록이 되어있습니다.");
+            }
+
+            if (budget.getTotalExpense().compareTo(BigDecimal.ZERO) > 0) {
+                throw new RuntimeException("오늘은 지출이 등록되어있습니다. 확인해주세요.");
+            }
+            handle_under10000Challenge(member, budget, false, true);
+            handle_zerofoodChallenge(member);
+            return;
+        }
+
+        // budget이 없으면 새로 생성
+        Budget newBudget = new Budget();
+        newBudget.setMember(member);
+        newBudget.setDate(today);
+        newBudget.setTotalIncome(BigDecimal.ZERO);
+        newBudget.setTotalExpense(BigDecimal.ZERO);
+        budgetRepository.save(newBudget);
+
+        handle_under10000Challenge(member, newBudget, false, true);
+        handle_zerofoodChallenge(member);
 
     }
 
 
-    public void handle_under10000Challenge(Member member, Budget budget, boolean empty, boolean hasOtherDetails) {
+    public void handle_under10000Challenge(Member member, Budget budget, boolean empty,
+        boolean hasOtherDetails) {
 
         LocalDate today = LocalDate.now();
         Challenge challenge = challengeRepository.findByname("만원의 행복")
             .orElseThrow(() -> new RuntimeException("챌린지 정보 없음"));
 
         // 이미 오늘 생성된 ChallengeCount가 있는지 확인
-        Optional<ChallengeCount> existingCount = challengeCountRepository
-            .findByMemberAndChallengeAndCreatedAtBetween(
-                member,
-                challenge,
-                today.atStartOfDay(),
-                today.plusDays(1).atStartOfDay()
-            );
+        Optional<ChallengeCount> existingCount = getChallengeCount(
+            member, challenge, today);
 
-        if (budget.getTotalExpense().compareTo(BigDecimal.valueOf(10000)) <= 0 && !empty && hasOtherDetails)
-        {
+        if (budget.getTotalExpense().compareTo(BigDecimal.valueOf(10000)) <= 0 && !empty
+            && hasOtherDetails) {
             if (existingCount.isEmpty()) {
                 // 없으면 새로 생성
                 ChallengeCount challengeCount = new ChallengeCount();
@@ -234,22 +257,66 @@ public class BudgetDetailService {
                 challengeCount.setChallenge(challenge);
 
                 challengeCountRepository.save(challengeCount);
-            }
-            else
-            {
+            } else {
                 ChallengeCount count = existingCount.get();
                 count.setCount(1);
                 challengeCountRepository.save(count);
             }
-        }
-        else
-        {
-            if (existingCount.isPresent())
-            {
+        } else {
+            if (existingCount.isPresent()) {
                 ChallengeCount count = existingCount.get();
                 count.setCount(0);
                 challengeCountRepository.save(count);
             }
         }
     }
+
+
+    public void handle_zerofoodChallenge(Member member) {
+
+        LocalDate today = LocalDate.now();
+        Challenge challenge = challengeRepository.findByname("소비 단식러")
+            .orElseThrow(() -> new RuntimeException("챌린지 정보 없음"));
+
+        Optional<ChallengeCount> existingCount = getChallengeCount(
+            member, challenge, today);
+
+        boolean existsByBudget = budgetRepository.existsBudgetByMemberIdAndDate(member.getMemberId(), LocalDate.now());
+        boolean  existsByCategory= budgetDetailRepository.existsBudgetDetailByMemberAndDate(member.getMemberId(), "식비", LocalDate.now());
+
+        if (existingCount.isEmpty()) {
+            // 없으면 새로 생성
+            ChallengeCount challengeCount = new ChallengeCount();
+            challengeCount.setMember(member);
+            challengeCount.setCount(0);
+            challengeCount.setChallenge(challenge);
+
+            challengeCountRepository.save(challengeCount);
+            existingCount = Optional.of(challengeCount);
+        }
+
+        ChallengeCount count = existingCount.get();
+        if(!existsByBudget || existsByCategory)
+        {
+            count.setCount(0);
+        }
+        else {
+            count.setCount(1);
+        }
+        challengeCountRepository.save(count);
+
+    }
+
+    private Optional<ChallengeCount> getChallengeCount(Member member, Challenge challenge,
+        LocalDate today) {
+        Optional<ChallengeCount> existingCount = challengeCountRepository
+            .findByMemberAndChallengeAndCreatedAtBetween(
+                member,
+                challenge,
+                today.atStartOfDay(),
+                today.plusDays(1).atStartOfDay()
+            );
+        return existingCount;
+    }
 }
+

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/domain/Challenge.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/domain/Challenge.java
@@ -20,18 +20,8 @@ import lombok.Setter;
 @Setter
 public class Challenge {
 
-    @Id
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(nullable = false, updatable = false)
-    @SequenceGenerator(
-            name = "primary_sequence",
-            sequenceName = "primary_sequence",
-            allocationSize = 1,
-            initialValue = 10000
-    )
-    @GeneratedValue(
-            strategy = GenerationType.SEQUENCE,
-            generator = "primary_sequence"
-    )
     private Long challengeId;
 
     @Column(nullable = false)
@@ -45,6 +35,13 @@ public class Challenge {
 
     @Column
     private Integer exp;
+
+    @Column
+    private String icon;
+
+    @Column
+    private Integer total;
+
 
     @OneToMany(mappedBy = "challenge")
     private Set<ChallengeCount> challengeCounts = new HashSet<>();

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/model/ChallengeStatusDto.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/model/ChallengeStatusDto.java
@@ -1,0 +1,24 @@
+package com.grepp.spring.app.model.challenge.model;
+
+import com.grepp.spring.app.model.challenge.domain.Challenge;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChallengeStatusDto {
+
+    private Long challengeId;
+    private String name;
+    private String description;
+    private String type;
+    private int total;
+    private int progress;
+    private String icon;
+}

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/repos/ChallengeRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/repos/ChallengeRepository.java
@@ -1,8 +1,40 @@
 package com.grepp.spring.app.model.challenge.repos;
 
 import com.grepp.spring.app.model.challenge.domain.Challenge;
+import com.grepp.spring.app.model.challenge.model.ChallengeStatusDto;
+import feign.Param;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+
+
+    @Query("""
+    SELECT new com.grepp.spring.app.model.challenge.model.ChallengeStatusDto(
+        c.challengeId,
+        c.name,
+        c.description,
+        c.type,
+        c.total,
+        COALESCE(cc.count, 0),
+        c.icon
+    )
+    FROM Challenge c
+    LEFT JOIN ChallengeCount cc ON cc.challenge = c AND cc.member.memberId = :memberId
+        AND (
+            (c.type = '일일' AND FUNCTION('DATE', cc.createdAt) = :today)
+            OR (c.type = '월간' AND FUNCTION('TO_CHAR', cc.createdAt, 'YYYY-MM') = :currentMonth)
+            OR (c.type = '커뮤니티')
+        )
+    ORDER BY c.challengeId
+""")
+    List<ChallengeStatusDto> findWithCount(@Param("memberId") Long memberId,
+        @Param("today") LocalDate today,
+        @Param("currentMonth") String currentMonth);
+
+    Optional<Challenge> findByname(String name);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/service/ChallengeService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/service/ChallengeService.java
@@ -1,98 +1,27 @@
 package com.grepp.spring.app.model.challenge.service;
 
-import com.grepp.spring.app.model.achieved_title.domain.AchievedTitle;
-import com.grepp.spring.app.model.achieved_title.repos.AchievedTitleRepository;
-import com.grepp.spring.app.model.challenge.domain.Challenge;
-import com.grepp.spring.app.model.challenge.model.ChallengeDTO;
-import com.grepp.spring.app.model.challenge.repos.ChallengeRepository;
-import com.grepp.spring.app.model.challenge_count.domain.ChallengeCount;
-import com.grepp.spring.app.model.challenge_count.repos.ChallengeCountRepository;
-import com.grepp.spring.util.NotFoundException;
-import com.grepp.spring.util.ReferencedWarning;
-import java.util.List;
-import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Service;
 
+import com.grepp.spring.app.model.challenge.domain.Challenge;
+import com.grepp.spring.app.model.challenge.model.ChallengeStatusDto;
+import com.grepp.spring.app.model.challenge.repos.ChallengeRepository;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class ChallengeService {
 
     private final ChallengeRepository challengeRepository;
-    private final ChallengeCountRepository challengeCountRepository;
-    private final AchievedTitleRepository achievedTitleRepository;
 
-    public ChallengeService(final ChallengeRepository challengeRepository,
-            final ChallengeCountRepository challengeCountRepository,
-            final AchievedTitleRepository achievedTitleRepository) {
-        this.challengeRepository = challengeRepository;
-        this.challengeCountRepository = challengeCountRepository;
-        this.achievedTitleRepository = achievedTitleRepository;
+    @Transactional(readOnly = true)
+    public List<ChallengeStatusDto> getChallengeStatuses(Long memberId) {
+        LocalDate today = LocalDate.now();
+        String currentMonth = YearMonth.now().toString(); // ex: "2025-07"
+
+        return challengeRepository.findWithCount(memberId, today, currentMonth);
     }
-
-    public List<ChallengeDTO> findAll() {
-        final List<Challenge> challenges = challengeRepository.findAll(Sort.by("challengeId"));
-        return challenges.stream()
-                .map(challenge -> mapToDTO(challenge, new ChallengeDTO()))
-                .toList();
-    }
-
-    public ChallengeDTO get(final Long challengeId) {
-        return challengeRepository.findById(challengeId)
-                .map(challenge -> mapToDTO(challenge, new ChallengeDTO()))
-                .orElseThrow(NotFoundException::new);
-    }
-
-    public Long create(final ChallengeDTO challengeDTO) {
-        final Challenge challenge = new Challenge();
-        mapToEntity(challengeDTO, challenge);
-        return challengeRepository.save(challenge).getChallengeId();
-    }
-
-    public void update(final Long challengeId, final ChallengeDTO challengeDTO) {
-        final Challenge challenge = challengeRepository.findById(challengeId)
-                .orElseThrow(NotFoundException::new);
-        mapToEntity(challengeDTO, challenge);
-        challengeRepository.save(challenge);
-    }
-
-    public void delete(final Long challengeId) {
-        challengeRepository.deleteById(challengeId);
-    }
-
-    private ChallengeDTO mapToDTO(final Challenge challenge, final ChallengeDTO challengeDTO) {
-        challengeDTO.setChallengeId(challenge.getChallengeId());
-        challengeDTO.setName(challenge.getName());
-        challengeDTO.setDescription(challenge.getDescription());
-        challengeDTO.setType(challenge.getType());
-        challengeDTO.setExp(challenge.getExp());
-        return challengeDTO;
-    }
-
-    private Challenge mapToEntity(final ChallengeDTO challengeDTO, final Challenge challenge) {
-        challenge.setName(challengeDTO.getName());
-        challenge.setDescription(challengeDTO.getDescription());
-        challenge.setType(challengeDTO.getType());
-        challenge.setExp(challengeDTO.getExp());
-        return challenge;
-    }
-
-    public ReferencedWarning getReferencedWarning(final Long challengeId) {
-        final ReferencedWarning referencedWarning = new ReferencedWarning();
-        final Challenge challenge = challengeRepository.findById(challengeId)
-                .orElseThrow(NotFoundException::new);
-        final ChallengeCount challengeChallengeCount = challengeCountRepository.findFirstByChallenge(challenge);
-        if (challengeChallengeCount != null) {
-            referencedWarning.setKey("challenge.challengeCount.challenge.referenced");
-            referencedWarning.addParam(challengeChallengeCount.getChallengeCountId());
-            return referencedWarning;
-        }
-        final AchievedTitle challengeAchievedTitle = achievedTitleRepository.findFirstByChallenge(challenge);
-        if (challengeAchievedTitle != null) {
-            referencedWarning.setKey("challenge.achievedTitle.challenge.referenced");
-            referencedWarning.addParam(challengeAchievedTitle.getATId());
-            return referencedWarning;
-        }
-        return null;
-    }
-
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge_count/domain/ChallengeCount.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge_count/domain/ChallengeCount.java
@@ -2,6 +2,7 @@ package com.grepp.spring.app.model.challenge_count.domain;
 
 import com.grepp.spring.app.model.challenge.domain.Challenge;
 import com.grepp.spring.app.model.member.domain.Member;
+import com.grepp.spring.infra.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -18,22 +19,10 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
-public class ChallengeCount {
+public class ChallengeCount extends BaseEntity {
 
-    @Id
-    @Column(nullable = false, updatable = false)
-    @SequenceGenerator(
-            name = "primary_sequence",
-            sequenceName = "primary_sequence",
-            allocationSize = 1,
-            initialValue = 10000
-    )
-    @GeneratedValue(
-            strategy = GenerationType.SEQUENCE,
-            generator = "primary_sequence"
-    )
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long challengeCountId;
-
 
     @Column(nullable = false)
     private Integer count;

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge_count/repos/ChallengeCountRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge_count/repos/ChallengeCountRepository.java
@@ -4,6 +4,8 @@ import com.grepp.spring.app.model.challenge.domain.Challenge;
 import com.grepp.spring.app.model.challenge_count.domain.ChallengeCount;
 import com.grepp.spring.app.model.challenge_count.model.ChallengeTopResponse;
 import com.grepp.spring.app.model.member.domain.Member;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -27,4 +29,7 @@ public interface ChallengeCountRepository extends JpaRepository<ChallengeCount, 
         ORDER BY SUM(cc.count) DESC
     """)
     List<ChallengeTopResponse> findTopAchievedChallengeNames(Pageable pageable);
+
+
+    Optional<ChallengeCount> findByMemberAndChallengeAndCreatedAtBetween(Member member, Challenge challenge, LocalDateTime localDateTime, LocalDateTime localDateTime1);
 }


### PR DESCRIPTION
📋 구현 내용

1. 소비단식러챌린지 성공기준 (progress =1)
                                1. 오늘 가계부의 카테고리에 식비가 없을 시
                                2. 오늘 가계부를 지출없음으로 등록시
                              
2. 소비단식러챌린지 실패기준 ( progress = 0)
                                1. 오늘 가계부의 카테고리에 식비가 있을 시
                                2. 오늘 가계부를 아예 작성 안 했을 시 ( 가계부를 작성했다가 모든내역을 삭제하거나, 다른날짜로 수정을해서 당일  
                                                                                           가계부에 내역이 없는상태가 된다면 가계부 작성 안 한것으로 처리) 
                               
3. 강철다리챌린지 성공기준 (progress =1)
                                1. 오늘 가계부의 카테고리에 교통비가 없을 시
                                2. 오늘 가계부를 지출없음으로 등록시
                              
4. 강철다리챌린지 실패기준 ( progress = 0)
                                1. 오늘 가계부의 교통비에 식비가 있을 시
                                2. 오늘 가계부를 아예 작성 안 했을 시 ( 가계부를 작성했다가 모든내역을 삭제하거나, 다른날짜로 수정을해서 당일  
                                                                                           가계부에 내역이 없는상태가 된다면 가계부 작성 안 한것으로 처리) 
                               
5. 챌린지 전체 조회시 ApiResponse로 응답

6. 지출없음 등록시 챌린지 반영되게 수정