### PR TITLE
Feature: 개근왕, 머니 매니저, 기록장인, 절약왕챌린지

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/attendance/repos/AttendanceRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/attendance/repos/AttendanceRepository.java
@@ -2,6 +2,7 @@ package com.grepp.spring.app.model.attendance.repos;
 
 import com.grepp.spring.app.model.attendance.domain.Attendance;
 import com.grepp.spring.app.model.member.domain.Member;
+import java.time.LocalDate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
@@ -9,4 +10,5 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
 
     Attendance findFirstByMember(Member member);
 
+    boolean existsByMemberAndDate(Member member, LocalDate today);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget/model/BudgetDaySummary.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget/model/BudgetDaySummary.java
@@ -20,4 +20,10 @@ public class BudgetDaySummary {
     private BigDecimal expense;
     private BigDecimal difference;
 
+    public BudgetDaySummary(LocalDate date, BigDecimal income, BigDecimal expense) {
+        this.date = date;
+        this.income = income != null ? income : BigDecimal.ZERO;
+        this.expense = expense != null ? expense : BigDecimal.ZERO;
+        this.difference = this.income.subtract(this.expense);
+    }
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget/repos/BudgetRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget/repos/BudgetRepository.java
@@ -88,4 +88,11 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
         @Param("end") LocalDate end);
 
     boolean existsByMemberAndDate(Member member, LocalDate yesterday);
+
+    @Query("SELECT SUM(b.totalExpense) FROM Budget b WHERE b.member.memberId = :memberId AND b.date BETWEEN :start AND :end")
+    BigDecimal sumExpenseByMemberAndDateBetween(
+        @Param("memberId") Long memberId,
+        @Param("start") LocalDate start,
+        @Param("end") LocalDate end
+    );
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget/repos/BudgetRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget/repos/BudgetRepository.java
@@ -87,4 +87,5 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
         @Param("start") LocalDate start,
         @Param("end") LocalDate end);
 
+    boolean existsByMemberAndDate(Member member, LocalDate yesterday);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget/repos/BudgetRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget/repos/BudgetRepository.java
@@ -1,6 +1,7 @@
 package com.grepp.spring.app.model.budget.repos;
 
 import com.grepp.spring.app.model.budget.domain.Budget;
+import com.grepp.spring.app.model.budget.model.BudgetDaySummary;
 import com.grepp.spring.app.model.member.domain.Member;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -76,4 +77,14 @@ public interface BudgetRepository extends JpaRepository<Budget, Long> {
     """)
     boolean existsBudgetByMemberIdAndDate(@Param("memberId") Long memberId,
         @Param("date") LocalDate date);
+
+    @Query("""
+          SELECT new com.grepp.spring.app.model.budget.model.BudgetDaySummary(b.date, b.totalIncome, b.totalExpense) 
+          FROM Budget b 
+          WHERE b.member.memberId = :memberId AND b.date BETWEEN :start AND :end ORDER BY b.date ASC
+          """)
+    List<BudgetDaySummary> findMonthlySummary(@Param("memberId") Long memberId,
+        @Param("start") LocalDate start,
+        @Param("end") LocalDate end);
+
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget/service/BudgetCalendarService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget/service/BudgetCalendarService.java
@@ -3,6 +3,7 @@ package com.grepp.spring.app.model.budget.service;
 import com.grepp.spring.app.model.budget.domain.Budget;
 import com.grepp.spring.app.model.budget.model.BudgetCalendarResponseDto;
 import com.grepp.spring.app.model.budget.model.BudgetDaySummary;
+import com.grepp.spring.app.model.budget.repos.BudgetRepository;
 import com.grepp.spring.app.model.budget_detail.repos.BudgetDetailRepository;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -20,13 +21,14 @@ import org.springframework.stereotype.Service;
 public class BudgetCalendarService {
 
     private final BudgetDetailRepository budgetDetailRepository;
+    private final BudgetRepository budgetRepository;
 
     public BudgetCalendarResponseDto getMonthlySummary(Long memberId, String yearmonth) {
 
         LocalDate today = LocalDate.now();
 
         Map<String, BigDecimal> totals = getMonthlySummaryUpToToday(memberId);
-        List<BudgetDaySummary> days = getDailySummaries(memberId,yearmonth);
+        List<BudgetDaySummary> days = getDailySummaries(memberId, yearmonth);
 
         return BudgetCalendarResponseDto.builder()
             .month(yearmonth)
@@ -42,7 +44,7 @@ public class BudgetCalendarService {
         LocalDate start = today.withDayOfMonth(1);
 
         // 1. 전체 총합
-        List<Budget> budgets = budgetDetailRepository.findTotalIncomeAndExpense(memberId,start,
+        List<Budget> budgets = budgetDetailRepository.findTotalIncomeAndExpense(memberId, start,
             today);
 
         BigDecimal totalIncome = BigDecimal.ZERO;
@@ -63,46 +65,14 @@ public class BudgetCalendarService {
         );
     }
 
-    public List<BudgetDaySummary> getDailySummaries(Long memberId,String yearmonth)
-    {
+    public List<BudgetDaySummary> getDailySummaries(Long memberId, String yearmonth) {
         YearMonth ym = YearMonth.parse(yearmonth); // "2025-07"
         LocalDate start = ym.atDay(1);
-        LocalDate end= start.withDayOfMonth(start.lengthOfMonth());
-        List<Object[]> rows = budgetDetailRepository.findDailySummary(memberId, start, end);
+        LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
 
-        // 날짜별로 합계 저장
-        Map<LocalDate, BudgetDaySummary> map = new HashMap<>();
-
-        for (Object[] row : rows) {
-            LocalDate date = (LocalDate) row[0];
-            String type = (String) row[1];
-            BigDecimal amount = new BigDecimal(row[2].toString());
-
-            if(!map.containsKey(date))
-            {
-                map.put(date, BudgetDaySummary.builder()
-                    .date(date)
-                    .income(BigDecimal.ZERO)
-                    .expense(BigDecimal.ZERO)
-                    .difference(BigDecimal.ZERO)
-                    .build()
-                );
-            }
-
-            BudgetDaySummary summary = map.get(date);
-
-            if ("수입".equals(type)) {
-                summary.setIncome(amount);
-            } else if ("지출".equals(type)) {
-                summary.setExpense(amount);
-            }
-
-            // 매번 수입-지출 계산
-            summary.setDifference(summary.getIncome().subtract(summary.getExpense()));
-
-        }
-        return map.values().stream()
-            .sorted(Comparator.comparing(BudgetDaySummary::getDate))
-            .collect(Collectors.toList());
+        List<BudgetDaySummary> budgets = budgetRepository.findMonthlySummary(memberId, start, end);
+        return budgets;
     }
+
+
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget_detail/repos/BudgetDetailRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget_detail/repos/BudgetDetailRepository.java
@@ -80,4 +80,15 @@ public interface BudgetDetailRepository extends JpaRepository<BudgetDetail, Long
     boolean existsBudgetDetailByMemberAndDate(@Param("memberId") Long memberId,
         @Param("category") String category,
         @Param("date") LocalDate date);
+
+    @Query("""
+    SELECT COUNT(d) > 0
+    FROM BudgetDetail d
+    WHERE d.budget.member.memberId = :memberId
+      AND d.type = :type
+      AND d.date = :date
+""")
+    boolean existsTypelByMemberAndDate(@Param("memberId") Long memberId,
+        @Param("type") String type,
+        @Param("date") LocalDate date);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget_detail/service/BudgetDetailService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget_detail/service/BudgetDetailService.java
@@ -10,6 +10,7 @@ import com.grepp.spring.app.model.budget_detail.model.UpdatedBudgetDetailRespons
 import com.grepp.spring.app.model.budget_detail.repos.BudgetDetailRepository;
 import com.grepp.spring.app.model.challenge.domain.Challenge;
 import com.grepp.spring.app.model.challenge.repos.ChallengeRepository;
+import com.grepp.spring.app.model.challenge.service.ChallengeService;
 import com.grepp.spring.app.model.challenge_count.domain.ChallengeCount;
 import com.grepp.spring.app.model.challenge_count.repos.ChallengeCountRepository;
 import com.grepp.spring.app.model.member.domain.Member;
@@ -36,6 +37,7 @@ public class BudgetDetailService {
     private final MemberRepository memberRepository;
     private final ChallengeRepository challengeRepository;
     private final ChallengeCountRepository challengeCountRepository;
+    private final ChallengeService challengeService;
 
     @Transactional(readOnly = true)
     public BudgetDetailResponseDto findBudgetDetailByDate(String username, String date) {
@@ -93,6 +95,8 @@ public class BudgetDetailService {
 
             //강철 다리
             handle_zeroTransitionChallenge(member);
+
+            challengeService.handle_salaryChallenge(member);
 
         }
     }
@@ -153,6 +157,8 @@ public class BudgetDetailService {
         // 강철다리
         handle_zeroTransitionChallenge(member);
 
+        challengeService.handle_salaryChallenge(member);
+
         return new UpdatedBudgetDetailResponseDto(
             detailId,
             budgetDetail.getType(),
@@ -193,6 +199,8 @@ public class BudgetDetailService {
 
         //강철다리
         handle_zeroTransitionChallenge(member);
+
+        challengeService.handle_salaryChallenge(member);
     }
 
     @Transactional

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget_detail/service/BudgetDetailService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget_detail/service/BudgetDetailService.java
@@ -96,8 +96,11 @@ public class BudgetDetailService {
             //강철 다리
             handle_zeroTransitionChallenge(member);
 
+            //머니 매니저
             challengeService.handle_salaryChallenge(member);
 
+            //기록장인
+            challengeService.handle_oneMonthAccountChallenge(member);
         }
     }
 
@@ -159,6 +162,9 @@ public class BudgetDetailService {
 
         challengeService.handle_salaryChallenge(member);
 
+        //기록장인
+        challengeService.handle_oneMonthAccountChallenge(member);
+
         return new UpdatedBudgetDetailResponseDto(
             detailId,
             budgetDetail.getType(),
@@ -201,6 +207,9 @@ public class BudgetDetailService {
         handle_zeroTransitionChallenge(member);
 
         challengeService.handle_salaryChallenge(member);
+
+        //기록장인
+        challengeService.handle_oneMonthAccountChallenge(member);
     }
 
     @Transactional
@@ -237,6 +246,7 @@ public class BudgetDetailService {
             handle_under10000Challenge(member, budget, false, true);
             handle_zerofoodChallenge(member);
             handle_zeroTransitionChallenge(member);
+            challengeService.handle_oneMonthAccountChallenge(member);
         }
 
         // 등록
@@ -250,6 +260,7 @@ public class BudgetDetailService {
         handle_under10000Challenge(member, newBudget, false, true);
         handle_zerofoodChallenge(member);
         handle_zeroTransitionChallenge(member);
+        challengeService.handle_oneMonthAccountChallenge(member);
 
         return new ApiResponse<>("2000", "지출 없음으로 등록되었습니다.", null);
 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget_detail/service/BudgetDetailService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget_detail/service/BudgetDetailService.java
@@ -102,6 +102,8 @@ public class BudgetDetailService {
             //기록장인
             challengeService.handle_oneMonthAccountChallenge(member);
         }
+
+            challengeService.handle_saveMoneyChallenge(member);
     }
 
 
@@ -165,6 +167,8 @@ public class BudgetDetailService {
         //기록장인
         challengeService.handle_oneMonthAccountChallenge(member);
 
+        challengeService.handle_saveMoneyChallenge(member);
+
         return new UpdatedBudgetDetailResponseDto(
             detailId,
             budgetDetail.getType(),
@@ -210,6 +214,8 @@ public class BudgetDetailService {
 
         //기록장인
         challengeService.handle_oneMonthAccountChallenge(member);
+
+        challengeService.handle_saveMoneyChallenge(member);
     }
 
     @Transactional
@@ -247,6 +253,7 @@ public class BudgetDetailService {
             handle_zerofoodChallenge(member);
             handle_zeroTransitionChallenge(member);
             challengeService.handle_oneMonthAccountChallenge(member);
+            challengeService.handle_saveMoneyChallenge(member);
         }
 
         // 등록
@@ -261,6 +268,7 @@ public class BudgetDetailService {
         handle_zerofoodChallenge(member);
         handle_zeroTransitionChallenge(member);
         challengeService.handle_oneMonthAccountChallenge(member);
+        challengeService.handle_saveMoneyChallenge(member);
 
         return new ApiResponse<>("2000", "지출 없음으로 등록되었습니다.", null);
 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/service/ChallengeService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/service/ChallengeService.java
@@ -63,7 +63,7 @@ public class ChallengeService {
 
         boolean isAttended = attendanceRepository.existsByMemberAndDate(member, today);
 
-        if(isAttended) {
+        if (isAttended) {
             // 2. 오늘 challengeCount가 이미 증가했는지 확인
             boolean challengeCountUpdatedToday = challengeCountRepository.existsByMemberAndChallengeAndModifiedAtBetween(
                 member,
@@ -91,8 +91,10 @@ public class ChallengeService {
         Optional<ChallengeCount> existingCount = getChallengeCount(
             member, challenge, today);
 
-        boolean existsByBudget = budgetRepository.existsBudgetByMemberIdAndDate(member.getMemberId(), LocalDate.now());
-        boolean  existsByType= budgetDetailRepository.existsTypelByMemberAndDate(member.getMemberId(), "수입", LocalDate.now());
+        boolean existsByBudget = budgetRepository.existsBudgetByMemberIdAndDate(
+            member.getMemberId(), LocalDate.now());
+        boolean existsByType = budgetDetailRepository.existsTypelByMemberAndDate(
+            member.getMemberId(), "수입", LocalDate.now());
 
         if (existingCount.isEmpty()) {
             // 없으면 새로 생성
@@ -106,16 +108,68 @@ public class ChallengeService {
         }
 
         ChallengeCount count = existingCount.get();
-        if(existsByBudget && existsByType)
-        {
+        if (existsByBudget && existsByType) {
             count.setCount(1);
-        }
-        else {
+        } else {
             count.setCount(0);
         }
         challengeCountRepository.save(count);
 
     }
+
+    @Transactional
+    public void handle_oneMonthAccountChallenge(Member member) {
+
+        LocalDate today = LocalDate.now();
+        LocalDate yesterday = today.minusDays(1);
+
+        Challenge challenge = challengeRepository.findByname("기록 장인")
+            .orElseThrow(() -> new RuntimeException("챌린지 정보 없음"));
+
+        // 어제 출석 여부 체크
+        boolean attendedYesterday = attendanceRepository.existsByMemberAndDate(member, yesterday);
+
+        // 어제 가계부 작성 여부 체크
+        boolean hasBudgetYesterday = budgetRepository.existsByMemberAndDate(member, yesterday);
+
+        Optional<ChallengeCount> existingCount = getChallengeCount(
+            member, challenge, today);
+
+        if (existingCount.isEmpty()) {
+            // 없으면 새로 생성
+            ChallengeCount challengeCount = new ChallengeCount();
+            challengeCount.setMember(member);
+            challengeCount.setCount(1);
+            challengeCount.setChallenge(challenge);
+
+            challengeCountRepository.save(challengeCount);
+            existingCount = Optional.of(challengeCount);
+        }
+        ChallengeCount count = existingCount.get();
+
+        // 오늘 가계부 작성 여부 체크
+        boolean hasBudgetToday = budgetRepository.existsByMemberAndDate(member, today);
+        if (!hasBudgetToday) {
+            return; // 오늘 가계부 안 썼으면 아무것도 안 함
+        }
+
+        // 오늘 이미 count 처리했는지 확인 (중복 증가 방지)
+        if (count.getModifiedAt() != null && count.getModifiedAt().toLocalDate().isEqual(today)) {
+            return; // 오늘 이미 처리된 상태
+        }
+
+        if (attendedYesterday && hasBudgetYesterday) {
+            count.setCount(count.getCount() + 1); // 연속 작성 인정
+        } else {
+            count.setCount(1); // 연속 안 됨 → 처음부터 시작
+        }
+
+        count.setModifiedAt(LocalDateTime.now());
+        challengeCountRepository.save(count);
+    }
+
+
+
 
     private Optional<ChallengeCount> getChallengeCount(Member member, Challenge challenge,
         LocalDate today) {

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/service/ChallengeService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/service/ChallengeService.java
@@ -1,12 +1,20 @@
 package com.grepp.spring.app.model.challenge.service;
 
 
+import com.grepp.spring.app.model.attendance.repos.AttendanceRepository;
+import com.grepp.spring.app.model.budget.repos.BudgetRepository;
+import com.grepp.spring.app.model.budget_detail.repos.BudgetDetailRepository;
 import com.grepp.spring.app.model.challenge.domain.Challenge;
 import com.grepp.spring.app.model.challenge.model.ChallengeStatusDto;
 import com.grepp.spring.app.model.challenge.repos.ChallengeRepository;
+import com.grepp.spring.app.model.challenge_count.domain.ChallengeCount;
+import com.grepp.spring.app.model.challenge_count.repos.ChallengeCountRepository;
+import com.grepp.spring.app.model.member.domain.Member;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +24,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChallengeService {
 
     private final ChallengeRepository challengeRepository;
+    private final ChallengeCountRepository challengeCountRepository;
+    private final AttendanceRepository attendanceRepository;
+    private final BudgetDetailRepository budgetDetailRepository;
+    private final BudgetRepository budgetRepository;
 
     @Transactional(readOnly = true)
     public List<ChallengeStatusDto> getChallengeStatuses(Long memberId) {
@@ -23,5 +35,97 @@ public class ChallengeService {
         String currentMonth = YearMonth.now().toString(); // ex: "2025-07"
 
         return challengeRepository.findWithCount(memberId, today, currentMonth);
+    }
+
+    @Transactional
+    public void handle_oneMonthChallenge(Member member) {
+
+        LocalDate today = LocalDate.now();
+
+        Challenge challenge = challengeRepository.findByname("개근왕")
+            .orElseThrow(() -> new RuntimeException("챌린지 정보 없음"));
+
+        Optional<ChallengeCount> existingCount = getChallengeCount(
+            member, challenge, today);
+
+        if (existingCount.isEmpty()) {
+            // 없으면 새로 생성
+            ChallengeCount challengeCount = new ChallengeCount();
+            challengeCount.setMember(member);
+            challengeCount.setCount(1);
+            challengeCount.setChallenge(challenge);
+
+            challengeCountRepository.save(challengeCount);
+            existingCount = Optional.of(challengeCount);
+        }
+
+        ChallengeCount count = existingCount.get();
+
+        boolean isAttended = attendanceRepository.existsByMemberAndDate(member, today);
+
+        if(isAttended) {
+            // 2. 오늘 challengeCount가 이미 증가했는지 확인
+            boolean challengeCountUpdatedToday = challengeCountRepository.existsByMemberAndChallengeAndModifiedAtBetween(
+                member,
+                challenge,
+                today.atStartOfDay(),
+                today.plusDays(1).atStartOfDay()
+            );
+            if (!challengeCountUpdatedToday) {
+                // 3. 오늘은 아직 challengeCount 증가 안 했으니 +1
+                count.setCount(count.getCount() + 1);
+                challengeCountRepository.save(count);
+            }
+        }
+
+    }
+
+    @Transactional
+    public void handle_salaryChallenge(Member member) {
+
+        LocalDate today = LocalDate.now();
+
+        Challenge challenge = challengeRepository.findByname("머니 매니저")
+            .orElseThrow(() -> new RuntimeException("챌린지 정보 없음"));
+
+        Optional<ChallengeCount> existingCount = getChallengeCount(
+            member, challenge, today);
+
+        boolean existsByBudget = budgetRepository.existsBudgetByMemberIdAndDate(member.getMemberId(), LocalDate.now());
+        boolean  existsByType= budgetDetailRepository.existsTypelByMemberAndDate(member.getMemberId(), "수입", LocalDate.now());
+
+        if (existingCount.isEmpty()) {
+            // 없으면 새로 생성
+            ChallengeCount challengeCount = new ChallengeCount();
+            challengeCount.setMember(member);
+            challengeCount.setCount(0);
+            challengeCount.setChallenge(challenge);
+
+            challengeCountRepository.save(challengeCount);
+            existingCount = Optional.of(challengeCount);
+        }
+
+        ChallengeCount count = existingCount.get();
+        if(existsByBudget && existsByType)
+        {
+            count.setCount(1);
+        }
+        else {
+            count.setCount(0);
+        }
+        challengeCountRepository.save(count);
+
+    }
+
+    private Optional<ChallengeCount> getChallengeCount(Member member, Challenge challenge,
+        LocalDate today) {
+        Optional<ChallengeCount> existingCount = challengeCountRepository
+            .findByMemberAndChallengeAndCreatedAtBetween(
+                member,
+                challenge,
+                today.withDayOfMonth(1).atStartOfDay(),
+                today.withDayOfMonth(1).plusMonths(1).atStartOfDay()
+            );
+        return existingCount;
     }
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge_count/repos/ChallengeCountRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge_count/repos/ChallengeCountRepository.java
@@ -32,4 +32,8 @@ public interface ChallengeCountRepository extends JpaRepository<ChallengeCount, 
 
 
     Optional<ChallengeCount> findByMemberAndChallengeAndCreatedAtBetween(Member member, Challenge challenge, LocalDateTime localDateTime, LocalDateTime localDateTime1);
+
+    boolean existsByMemberAndChallengeAndModifiedAtBetween(Member member, Challenge challenge, LocalDateTime localDateTime, LocalDateTime localDateTime1);
+
+    ChallengeCount findByMemberAndChallenge(Member member, Challenge challenge);
 }


### PR DESCRIPTION
📋 구현 내용

개근왕챌린지(progress =1~30) -> 30이되면 성공
1. 출석하면 Attendance테이블에서 확인 후 progress수정

머니 매니저챌린지  ( progress = 1)
1. 이번 달 수입인 내역이 있으면 성공

기록장인 챌린지 (progress =1~30) -> 30이 되면 성공,  등록시 되고 수정삭제해서 가계부가 없어도 그 날 가계부작성한것으로 처리됨.. 수정필요하면 수정
1. 가계부 작성을 연속으로 했을 때 progress+1 

절약왕 챌린지 ( progress = 1)
1. 이번달 지출이 저번달 보다 적으면 성공
