### PR TITLE
Feature: 챌린지 칭호획득 알림기능

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/achieved_title/domain/AchievedTitle.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/achieved_title/domain/AchievedTitle.java
@@ -20,26 +20,18 @@ import lombok.Setter;
 @Setter
 public class AchievedTitle {
 
-    @Id
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(nullable = false, updatable = false)
-    @SequenceGenerator(
-            name = "primary_sequence",
-            sequenceName = "primary_sequence",
-            allocationSize = 1,
-            initialValue = 10000
-    )
-    @GeneratedValue(
-            strategy = GenerationType.SEQUENCE,
-            generator = "primary_sequence"
-    )
     private Long aTId;
-
 
     @Column(nullable = false)
     private String name;
 
     @Column(nullable = false)
     private Boolean achieved;
+
+    @Column
+    private String icon;
 
     @Column
     private Integer minCount;

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/achieved_title/repos/AchievedTitleRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/achieved_title/repos/AchievedTitleRepository.java
@@ -2,11 +2,15 @@ package com.grepp.spring.app.model.achieved_title.repos;
 
 import com.grepp.spring.app.model.achieved_title.domain.AchievedTitle;
 import com.grepp.spring.app.model.challenge.domain.Challenge;
+import com.grepp.spring.app.model.member.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface AchievedTitleRepository extends JpaRepository<AchievedTitle, Long> {
 
     AchievedTitle findFirstByChallenge(Challenge challenge);
+
+    Optional<AchievedTitle> findByMemberAndName(Member member, String name);
 
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget_detail/repos/BudgetDetailRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget_detail/repos/BudgetDetailRepository.java
@@ -5,6 +5,7 @@ import com.grepp.spring.app.model.budget.model.BudgetCategorySummary;
 import com.grepp.spring.app.model.budget_detail.domain.BudgetDetail;
 import feign.Param;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -91,4 +92,15 @@ public interface BudgetDetailRepository extends JpaRepository<BudgetDetail, Long
     boolean existsTypelByMemberAndDate(@Param("memberId") Long memberId,
         @Param("type") String type,
         @Param("date") LocalDate date);
+
+
+    @Query("SELECT COUNT(d) > 0 FROM BudgetDetail d " +
+        "WHERE d.budget.member.memberId = :memberId " +
+        "AND d.type = :type " +
+        "AND d.date >= :startDateTime " +
+        "AND d.date < :endDateTime")
+    boolean existsByTypeInMonth(@Param("memberId") Long memberId,
+        @Param("type") String type,
+        @Param("startDateTime") LocalDate startDateTime,
+        @Param("endDateTime") LocalDate endDateTime);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget_detail/service/BudgetDetailService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/budget_detail/service/BudgetDetailService.java
@@ -96,13 +96,11 @@ public class BudgetDetailService {
             //강철 다리
             handle_zeroTransitionChallenge(member);
 
-            //머니 매니저
-            challengeService.handle_salaryChallenge(member);
-
             //기록장인
             challengeService.handle_oneMonthAccountChallenge(member);
         }
-
+            //머니 매니저
+            challengeService.handle_salaryChallenge(member);
             challengeService.handle_saveMoneyChallenge(member);
     }
 
@@ -162,11 +160,13 @@ public class BudgetDetailService {
         // 강철다리
         handle_zeroTransitionChallenge(member);
 
+        // 머니매니저
         challengeService.handle_salaryChallenge(member);
 
         //기록장인
         challengeService.handle_oneMonthAccountChallenge(member);
 
+        // 절약왕
         challengeService.handle_saveMoneyChallenge(member);
 
         return new UpdatedBudgetDetailResponseDto(

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/service/ChallengeService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge/service/ChallengeService.java
@@ -1,6 +1,8 @@
 package com.grepp.spring.app.model.challenge.service;
 
 
+import com.grepp.spring.app.model.achieved_title.domain.AchievedTitle;
+import com.grepp.spring.app.model.achieved_title.repos.AchievedTitleRepository;
 import com.grepp.spring.app.model.attendance.repos.AttendanceRepository;
 import com.grepp.spring.app.model.budget.repos.BudgetRepository;
 import com.grepp.spring.app.model.budget_detail.repos.BudgetDetailRepository;
@@ -37,6 +39,7 @@ public class ChallengeService {
     private final MemberRepository memberRepository;
     private final NotificationService notificationService;
     private final NotificationRepository notificationRepository;
+    private final AchievedTitleRepository achievedTitleRepository;
 
     @Transactional(readOnly = true)
     public List<ChallengeStatusDto> getChallengeStatuses(Long memberId) {
@@ -100,14 +103,13 @@ public class ChallengeService {
         Optional<ChallengeCount> existingCount = getChallengeCount(
             member, challenge, today);
 
-        boolean existsByBudget = budgetRepository.existsBudgetByMemberIdAndDate(
-            member.getMemberId(), LocalDate.now());
-        boolean existsByType = budgetDetailRepository.existsTypelByMemberAndDate(
-            member.getMemberId(), "수입", LocalDate.now());
-
-
         LocalDateTime startOfMonth = today.withDayOfMonth(1).atStartOfDay();
         LocalDateTime endOfMonth = startOfMonth.plusMonths(1);
+
+//        boolean existsByBudget = budgetRepository.existsBudgetByMemberIdAndDate(
+//            member.getMemberId(), LocalDate.now());
+        boolean existsByType = budgetDetailRepository.existsByTypeInMonth(
+            member.getMemberId(), "수입", startOfMonth.toLocalDate(), endOfMonth.toLocalDate());
 
         boolean notification = notificationRepository.existsMonthlyNotification(member.getMemberId(), startOfMonth,
             endOfMonth,"머니 매니저 칭호를 획득했어요!");
@@ -124,11 +126,13 @@ public class ChallengeService {
         }
 
         ChallengeCount count = existingCount.get();
-        if (existsByBudget && existsByType) {
+        System.out.print(existsByType);
+        if (existsByType) {
             count.setCount(1);
             if(!notification)
             {
-                createnotification(member, count);
+                createdAchievedTitle(member,count);
+                createNotification(member, count);
             }
         } else {
             count.setCount(0);
@@ -251,6 +255,7 @@ public class ChallengeService {
         return existingCount;
     }
 
+    @Scheduled(cron = "0 0 0 * * *") // 매일 00시(자정)에 실행
     //@Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul") // 매 분 0초마다 실행
     public void daily_notifyChallengeSuccess() {
         LocalDateTime startOfYesterday = LocalDate.now().minusDays(1).atStartOfDay(); // 어제 00:00:00
@@ -266,7 +271,8 @@ public class ChallengeService {
             for (ChallengeCount cc : counts) {
                 if (cc.getCount() == cc.getChallenge().getTotal()) {
 
-                    createnotification(member, cc);
+                    createdAchievedTitle(member,cc);
+                    createNotification(member, cc);
                     System.out.println("✅ 챌린지 " + cc.getChallenge().getName() + " 성공");
                 } else {
                     System.out.println("❌ 챌린지 " + cc.getChallenge().getName() + " 실패");
@@ -275,8 +281,8 @@ public class ChallengeService {
         }
     }
 
-    // @Scheduled(cron = "0 0 0 1 * *")
-    //@Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")//매 달 1일
+     @Scheduled(cron = "0 0 0 1 * *") // 매달 1일에 실행
+    //@Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul") // 매 분 실행
     public void monthly_notifyChallengeSuccess() {
 
         LocalDateTime startOfLastMonth = LocalDate.now().minusMonths(1).withDayOfMonth(1).atStartOfDay(); // 7월 1일 00:00:00
@@ -295,9 +301,14 @@ public class ChallengeService {
             for (ChallengeCount cc : counts) {
                 if (cc.getCount() == cc.getChallenge().getTotal()) {
 
-                    if(!notification)
-                    {
-                        createnotification(member, cc);
+                    if (cc.getChallenge().getName().equals("머니 매니저")) {
+                        if (!notification) {
+                            createdAchievedTitle(member, cc);
+                            createNotification(member, cc);
+                        }
+                    } else {
+                        createdAchievedTitle(member, cc);
+                        createNotification(member, cc);
                     }
                     System.out.println("✅ 챌린지 " + cc.getChallenge().getName() + " 성공");
                 } else {
@@ -307,8 +318,26 @@ public class ChallengeService {
         }
     }
 
+    public void createdAchievedTitle(Member member,ChallengeCount cc) {
+        Optional<AchievedTitle> optional = achievedTitleRepository.findByMemberAndName(member,cc.getChallenge().getName());
 
-    private void createnotification(Member member, ChallengeCount cc) {
+        if (optional.isPresent()) {
+            AchievedTitle existing = optional.get();
+            existing.setMinCount(existing.getMinCount() + 1); // count 증가
+            achievedTitleRepository.save(existing);
+        } else {
+            AchievedTitle newTitle = new AchievedTitle();
+            newTitle.setName(cc.getChallenge().getName());
+            newTitle.setChallenge(cc.getChallenge());
+            newTitle.setAchieved(false);
+            newTitle.setMember(member);
+            newTitle.setIcon(cc.getChallenge().getIcon());
+            newTitle.setMinCount(1); // 처음은 1로 설정
+            achievedTitleRepository.save(newTitle);
+        }
+    }
+
+    private void createNotification(Member member, ChallengeCount cc) {
         NotificationCreateRequest request = new NotificationCreateRequest(
             member.getMemberId(),
             0L,
@@ -318,4 +347,6 @@ public class ChallengeService {
             cc.getChallenge().getName());
         notificationService.createNotification(request);
     }
+
+
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge_count/repos/ChallengeCountRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/challenge_count/repos/ChallengeCountRepository.java
@@ -4,6 +4,8 @@ import com.grepp.spring.app.model.challenge.domain.Challenge;
 import com.grepp.spring.app.model.challenge_count.domain.ChallengeCount;
 import com.grepp.spring.app.model.challenge_count.model.ChallengeTopResponse;
 import com.grepp.spring.app.model.member.domain.Member;
+import feign.Param;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -36,4 +38,16 @@ public interface ChallengeCountRepository extends JpaRepository<ChallengeCount, 
     boolean existsByMemberAndChallengeAndModifiedAtBetween(Member member, Challenge challenge, LocalDateTime localDateTime, LocalDateTime localDateTime1);
 
     ChallengeCount findByMemberAndChallenge(Member member, Challenge challenge);
+
+    @Query("SELECT cc FROM ChallengeCount cc " +
+        "JOIN FETCH cc.challenge c " +
+        "WHERE cc.member.memberId = :memberId " +
+        "AND cc.createdAt >= :startOfYesterday " +
+        "AND cc.createdAt < :startOfToday " +
+        "AND cc.challenge.type= :type")
+    List<ChallengeCount> findDailyChallenges(
+        @Param("memberId") Long memberId,
+        @Param("startOfYesterday") LocalDateTime startOfYesterday,
+        @Param("startOfToday") LocalDateTime startOfToday,
+        @Param("type") String type);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/repos/NotificationRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/repos/NotificationRepository.java
@@ -2,8 +2,11 @@ package com.grepp.spring.app.model.notification.repos;
 
 import com.grepp.spring.app.model.member.domain.Member;
 import com.grepp.spring.app.model.notification.domain.Notification;
+import feign.Param;
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
@@ -12,5 +15,16 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     // 멤버 ID, 타입, 활성화 상태로 알림 조회
     List<Notification> findByMemberMemberIdAndTypeAndActivatedTrue(Long memberId, String type);
+
+    @Query("SELECT COUNT(n) > 0 FROM Notification n " +
+        "WHERE n.member.memberId = :memberId " +
+        "AND n.createdAt >= :start " +
+        "AND n.createdAt < :end " +
+        "AND n.message = :message")
+    boolean existsMonthlyNotification(
+        @Param("member") Long memberId,
+        @Param("start") LocalDateTime start,
+        @Param("end") LocalDateTime end,
+        @Param("message") String message);
 
 }


### PR DESCRIPTION
📋 **구현 내용**

1. 스케줄러를 활용해서 칭호획득 시 알림이 가게하였습니다. 

 - 일일챌린지같은경우
 
        오늘이 7월22일이면 7월23일 00시00분00초가 됐을 때 7월22일의 일일챌린지의 달성여부를 판단해서 
        성공한 챌린지만 "○○○칭호 획득하였습니다" 라는 알림이가게되고 AchievedTitle테이블에 추가됩니다
        혹시 달성한 칭호가 있다면 count+1 하도록 구현

 - 월간챌린지같은경우 

         8월1일 00시00분00초가 되면 7월의 챌린지의 달성여부를 판단해서 일일챌린지와 마찬가지로 알림이 갑니다

2. AchievedTitle에 icon컬럼 추가하고 GenerationType.IDENTITY로 수정.

3. 일일미션은 자정에 알림, 월간도 매달1일에 알림이가는데 "머니 매니저"챌린지는 수입을 등록하자마자 알림이가고 칭호획득

**유의사항**
알림이 가는지 안 가는지 확인할 때 자정이나 다음달1일이 되야 확인할 수 있는데 ChallengeService에 주석처리된 스케줄러 사용하면 매 분 알림이 가도록 변경해서 확인할 수 있습니다 
월간 챌린지 같은경우는 저번달의 챌린지 데이터가 ChallengeCount에 있어야하고 일일챌린지도 어제의 챌린지 데이터가 있어야합니다

