### PR TITLE
비밀번호 찾기 API 직렬화 오류 및 CORS credentials 설정 개선

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
@@ -1001,7 +1001,7 @@ public class MemberController {
 
     @Getter @Setter @NoArgsConstructor
     public static class PasswordFindResponse {
-        // 응답 데이터 없음 (성공 메시지만 반환)
+        private String message = "임시 비밀번호가 이메일로 발송되었습니다.";
     }
 
     // 비밀번호 변경 관련 DTO

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/config/WebConfig.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/config/WebConfig.java
@@ -9,9 +9,9 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("*")
+                .allowedOrigins("http://localhost:3000")
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
-                .allowCredentials(false);
+                .allowCredentials(true);
     }
 }


### PR DESCRIPTION
## 비밀번호 찾기 API 직렬화 오류 및 CORS credentials 설정 개선

### 주요 변경사항

1. **비밀번호 찾기(임시 비밀번호 발급) API 500 에러 해결**
   - PasswordFindResponse DTO에 message 필드를 추가하여 Jackson 직렬화 오류(500 Internal Server Error) 해결
   - 임시 비밀번호 발급/이메일 발송 후 정상적으로 성공 메시지 응답 반환
   - 프론트엔드에서 비밀번호 찾기 결과를 안정적으로 받을 수 있음

2. **CORS 설정(credentials: 'include' 대응) 개선**
   - allowedOrigins를 'http://localhost:3000'으로 명시적으로 지정
   - allowCredentials 옵션을 true로 변경
   - 모든 HTTP 메서드 및 헤더 허용 유지
   - 프론트엔드에서 credentials: 'include' 옵션 사용 시 CORS 오류 없이 인증 쿠키가 정상적으로 전송됨