### PR TITLE
Fix: 챌린지 조회 

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/achieved_title/model/AchievedTitleDTO.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/achieved_title/model/AchievedTitleDTO.java
@@ -25,7 +25,17 @@ public class AchievedTitleDTO {
 
     private Integer minCount;
 
+    private String icon;
+
     @NotNull
     private Long challenge;
 
+    public AchievedTitleDTO(Long challengeId, String name, Integer minCount, String icon) {
+
+        this.challengeId = challengeId;
+        this.name = name;
+        this.minCount = minCount;
+        this.icon = icon;
+    }
+    public AchievedTitleDTO() {}
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/achieved_title/repos/AchievedTitleRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/achieved_title/repos/AchievedTitleRepository.java
@@ -1,10 +1,14 @@
 package com.grepp.spring.app.model.achieved_title.repos;
 
 import com.grepp.spring.app.model.achieved_title.domain.AchievedTitle;
+import com.grepp.spring.app.model.achieved_title.model.AchievedTitleDTO;
 import com.grepp.spring.app.model.challenge.domain.Challenge;
 import com.grepp.spring.app.model.member.domain.Member;
+import feign.Param;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 
 public interface AchievedTitleRepository extends JpaRepository<AchievedTitle, Long> {
@@ -14,4 +18,9 @@ public interface AchievedTitleRepository extends JpaRepository<AchievedTitle, Lo
     Optional<AchievedTitle> findByMemberAndName(Member member, String name);
 
     boolean existsByMemberAndChallenge(Member member, Challenge challenge);
+
+
+    @Query("SELECT new com.grepp.spring.app.model.achieved_title.model.AchievedTitleDTO(a.challenge.challengeId, a.name, a.minCount,a.icon) " +
+        "FROM AchievedTitle a WHERE a.member.memberId = :memberId")
+    List<AchievedTitleDTO> findDtoByMemberId(@Param("memberId") Long memberId);
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/repos/MemberRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/member/repos/MemberRepository.java
@@ -2,6 +2,7 @@ package com.grepp.spring.app.model.member.repos;
 
 import com.grepp.spring.app.model.member.domain.Member;
 import com.grepp.spring.app.model.member.model.TopSaversResponse;
+import feign.Param;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -65,4 +66,12 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     // 관리자 당일 통계(회원가입 수)
     int countByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
 
+
+    @Query("""
+    SELECT m FROM Member m
+    LEFT JOIN FETCH m.equippedTitle et
+    LEFT JOIN FETCH et.challenge
+    WHERE m.memberId = :memberId
+""")
+    Optional<Member> findWithEquippedTitleAndChallenge(@Param("memberId") Long memberId);
 }


### PR DESCRIPTION
📋 수정 내용
1. 마이페이지에서 달성한 챌린지 조회할 때 로그인 한 사용자의 데이터만 응답가게 수정하였습니다

2. 마이페이지에서 장착한 챌린지 조회할 때 Member테이블에 equipped가 있으면 값을 보내고 없으면 null

3. dto응답값을 api명세서에 명세된대로 challengeid,name,count,icon 4개만 응답값으로 보냈습니다