### PR TITLE
feat: 리프레시 토큰으로 엑세스 토큰 재발급 API 구현

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
@@ -1268,4 +1268,62 @@ public class MemberController {
             private String icon;
         }
     }
+
+    @PostMapping("/token/refresh")
+    @Operation(summary = "엑세스 토큰 재발급", description = "리프레시 토큰을 이용해 새로운 엑세스 토큰과 리프레시 토큰을 발급합니다.")
+    public ResponseEntity<ApiResponse<TokenRefreshResponse>> refreshToken(@RequestBody @Valid TokenRefreshRequest request, HttpServletResponse response) {
+        // 1. 전달받은 refreshToken 유효성 검사
+        String refreshToken = request.getRefreshToken();
+        if (refreshToken == null || refreshToken.isBlank()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ApiResponse<>(ResponseCode.BAD_REQUEST.code(), "리프레시 토큰이 필요합니다.", null));
+        }
+        // 2. refreshToken에서 accessToken jti 추출
+        String atId;
+        try {
+            atId = jwtTokenProvider.getJtiFromToken(refreshToken);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponse<>(ResponseCode.UNAUTHORIZED.code(), "유효하지 않은 리프레시 토큰입니다.", null));
+        }
+        // 3. Redis에서 refreshToken 정보 조회 및 검증
+        var stored = refreshTokenService.findByAccessTokenId(atId);
+        if (stored == null || !stored.getToken().equals(refreshToken)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ApiResponse<>(ResponseCode.UNAUTHORIZED.code(), "리프레시 토큰이 일치하지 않습니다.", null));
+        }
+        // 4. 새 accessToken/refreshToken 발급
+        String email = jwtTokenProvider.getUsername(refreshToken);
+        String roles = jwtTokenProvider.getRoles(refreshToken);
+        var accessTokenDto = jwtTokenProvider.generateAccessToken(email, roles);
+        var newRefreshToken = refreshTokenService.renewingToken(atId, accessTokenDto.getJti());
+        // 5. 쿠키로도 내려줌(선택)
+        ResponseCookie accessTokenCookie = TokenCookieFactory.create("accessToken", accessTokenDto.getToken(), accessTokenDto.getExpires());
+        ResponseCookie refreshTokenCookie = TokenCookieFactory.create("refreshToken", newRefreshToken.getToken(), newRefreshToken.getTtl());
+        response.addHeader("Set-Cookie", accessTokenCookie.toString());
+        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+        // 6. 응답
+        TokenRefreshResponse resp = new TokenRefreshResponse(accessTokenDto.getToken(), newRefreshToken.getToken(), "Bearer", accessTokenDto.getExpires(), newRefreshToken.getTtl());
+        return ResponseEntity.ok(ApiResponse.success(resp));
+    }
+
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
+    public static class TokenRefreshRequest {
+        @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+        private String refreshToken;
+    }
+
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
+    public static class TokenRefreshResponse {
+        @Schema(description = "새 엑세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+        private String accessToken;
+        @Schema(description = "새 리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+        private String refreshToken;
+        @Schema(description = "토큰 타입", example = "Bearer")
+        private String grantType;
+        @Schema(description = "엑세스 토큰 만료(ms)", example = "3600000")
+        private Long expiresIn;
+        @Schema(description = "리프레시 토큰 만료(ms)", example = "604800000")
+        private Long refreshExpiresIn;
+    }
 } 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/auth/jwt/JwtTokenProvider.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/auth/jwt/JwtTokenProvider.java
@@ -137,4 +137,21 @@ public class JwtTokenProvider {
             return e.getClaims();
         }
     }
+
+    // JWT에서 jti 추출
+    public String getJtiFromToken(String token) {
+        Claims claims = parseClaims(token);
+        return claims.getId();
+    }
+    // JWT에서 subject(email) 추출
+    public String getUsername(String token) {
+        Claims claims = parseClaims(token);
+        return claims.getSubject();
+    }
+    // JWT에서 roles 추출
+    public String getRoles(String token) {
+        Claims claims = parseClaims(token);
+        Object roles = claims.get("roles");
+        return roles != null ? roles.toString() : null;
+    }
 }


### PR DESCRIPTION
- /api/members/token/refresh 엔드포인트 추가 (POST)
- refreshToken을 받아 새 accessToken/refreshToken을 발급 및 쿠키로도 반환
- JwtTokenProvider에 getJtiFromToken, getUsername, getRoles 메서드 추가