### PR TITLE
feat: Gemini 기반 자산관리 챗봇 API - 최근 한달 지출 내역 자동 분석 기능 구현

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/geminichatbot/GeminiChatbotController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/geminichatbot/GeminiChatbotController.java
@@ -1,0 +1,75 @@
+package com.grepp.spring.app.controller.api.geminichatbot;
+
+import com.grepp.spring.app.model.auth.domain.Principal;
+import com.grepp.spring.app.model.geminichatbot.service.GeminiChatbotService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import java.util.Map;
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/geminichatbot")
+@Tag(name = "Gemini 챗봇", description = "Google Gemini 기반 자산관리 챗봇 API")
+public class GeminiChatbotController {
+    private final GeminiChatbotService geminiChatbotService;
+    @Autowired
+    public GeminiChatbotController(GeminiChatbotService geminiChatbotService) {
+        this.geminiChatbotService = geminiChatbotService;
+    }
+
+    @PostMapping("/analyze")
+    @Operation(summary = "자산관리 Gemini 챗봇 분석", description = "로그인 사용자의 최근 한달 지출 데이터를 기반으로 Gemini API를 호출해 소비 분석, 절약 피드백, 지출 줄이기 팁을 제공한다.")
+    public ResponseEntity<Map<String, String>> analyze(@AuthenticationPrincipal Principal principal) {
+        try {
+            Long memberId = principal.getMemberId();
+            String spendingData = geminiChatbotService.getSpendingDataForLastMonth(memberId);
+            String prompt = buildGeminiPrompt(spendingData);
+            String geminiResponse = callGemini(prompt);
+            String message = extractGeminiText(geminiResponse);
+            return ResponseEntity.ok(Map.of("message", message));
+        } catch (Exception e) {
+            return ResponseEntity.ok(Map.of("message", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요."));
+        }
+    }
+
+    private static String buildGeminiPrompt(String spendingData) {
+        return "아래는 사용자의 최근 한 달 지출 내역입니다.\n" +
+                spendingData +
+                "\n1. 전체 소비 패턴을 요약해줘.\n2. 절약 정도에 대한 피드백을 줘.\n3. 지출이 많은 부분을 줄일 수 있는 구체적인 팁을 알려줘.";
+    }
+
+    private static String callGemini(String prompt) throws IOException, InterruptedException {
+        String apiKey = "AIzaSyDvCXZ9xn9KCNUIznjqKWXSZVT5QWWWxG8";
+        String apiUrl = "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=" + apiKey;
+        String requestBody = "{\"contents\":[{\"parts\":[{\"text\":\"" + prompt.replace("\"", "\\\"") + "\"}]}]}";
+        java.net.http.HttpClient client = java.net.http.HttpClient.newHttpClient();
+        java.net.http.HttpRequest request = java.net.http.HttpRequest.newBuilder()
+                .uri(java.net.URI.create(apiUrl))
+                .header("Content-Type", "application/json")
+                .POST(java.net.http.HttpRequest.BodyPublishers.ofString(requestBody))
+                .build();
+        java.net.http.HttpResponse<String> response = client.send(request, java.net.http.HttpResponse.BodyHandlers.ofString());
+        return response.body();
+    }
+
+    private static String extractGeminiText(String geminiResponse) {
+        try {
+            com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+            com.fasterxml.jackson.databind.JsonNode root = mapper.readTree(geminiResponse);
+            return root.path("candidates").get(0)
+                    .path("content").path("parts").get(0)
+                    .path("text").asText();
+        } catch (Exception e) {
+            return "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요.";
+        }
+    }
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
@@ -51,6 +51,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 import com.grepp.spring.app.model.challenge.service.ChallengeService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/api/members")

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/geminichatbot/repos/GeminiChatbotBudgetDetailRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/geminichatbot/repos/GeminiChatbotBudgetDetailRepository.java
@@ -1,0 +1,23 @@
+package com.grepp.spring.app.model.geminichatbot.repos;
+
+import com.grepp.spring.app.model.budget_detail.domain.BudgetDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface GeminiChatbotBudgetDetailRepository extends JpaRepository<BudgetDetail, Long> {
+    @Query("""
+        SELECT d FROM BudgetDetail d
+        WHERE d.budget.member.memberId = :memberId
+          AND d.date BETWEEN :start AND :end
+          AND d.type = '지출'
+        ORDER BY d.date
+    """)
+    List<BudgetDetail> findExpenseDetailsByMemberIdAndDateBetween(
+        @Param("memberId") Long memberId,
+        @Param("start") LocalDate start,
+        @Param("end") LocalDate end
+    );
+} 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/geminichatbot/service/GeminiChatbotService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/geminichatbot/service/GeminiChatbotService.java
@@ -1,0 +1,30 @@
+package com.grepp.spring.app.model.geminichatbot.service;
+
+import com.grepp.spring.app.model.budget_detail.domain.BudgetDetail;
+import com.grepp.spring.app.model.geminichatbot.repos.GeminiChatbotBudgetDetailRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GeminiChatbotService {
+    private final GeminiChatbotBudgetDetailRepository budgetDetailRepository;
+
+    public String getSpendingDataForLastMonth(Long memberId) {
+        LocalDate end = LocalDate.now();
+        LocalDate start = end.minusMonths(1).plusDays(1);
+        List<BudgetDetail> details = budgetDetailRepository.findExpenseDetailsByMemberIdAndDateBetween(memberId, start, end);
+        StringBuilder sb = new StringBuilder();
+        for (BudgetDetail d : details) {
+            sb.append(d.getDate())
+              .append(": ")
+              .append(d.getCategory())
+              .append(" ")
+              .append(d.getPrice().intValue())
+              .append("원\n");
+        }
+        return sb.toString();
+    }
+} 


### PR DESCRIPTION
# Gemini 기반 자산관리 챗봇 API - 최근 한달 지출 내역 자동 분석 기능

## 주요 변경사항
- /api/geminichatbot/analyze 엔드포인트 신설 (POST)
- 로그인한 사용자의 최근 한달간 지출 상세내역을 DB에서 자동 조회
- BudgetDetail에서 날짜/카테고리/금액 단위로 프롬프트 생성 후 Gemini API 호출
- Gemini 응답을 { "message": ~ } 형태로 반환 (예외 시 동일 포맷)
- 별도 패키지(geminichatbot) 및 컨트롤러/서비스/레포지토리 구조로 분리
- 인증 정보(@AuthenticationPrincipal)만으로 동작, 별도 요청 바디 불필요