### PR TITLE
 feat: 칭호 획득 알림 응답에 aTId 필드 추가

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/geminichatbot/GeminiChatbotController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/geminichatbot/GeminiChatbotController.java
@@ -44,24 +44,31 @@ public class GeminiChatbotController {
         // 요청 횟수 체크
         if (!checkAndIncrementRequestCount(memberId)) {
             return ResponseEntity.ok(Map.of(
-                "spendingPattern", "하루에 최대 3번까지만 요청할 수 있습니다.",
-                "savingFeedback", "하루에 최대 3번까지만 요청할 수 있습니다.",
-                "spendingTips", "하루에 최대 3번까지만 요청할 수 있습니다."
+                "response1", "하루에 최대 3번까지만 요청할 수 있습니다.",
+                "response2", "하루에 최대 3번까지만 요청할 수 있습니다.",
+                "response3", "하루에 최대 3번까지만 요청할 수 있습니다.",
+                "response4", "하루에 최대 3번까지만 요청할 수 있습니다.",
+                "response5", "하루에 최대 3번까지만 요청할 수 있습니다.",
+                "response6", "하루에 최대 3번까지만 요청할 수 있습니다."
             ));
         }
         
         try {
             String spendingData = geminiChatbotService.getSpendingDataForLastMonth(memberId);
-            String prompt = buildGeminiPrompt(spendingData);
+            String averageData = geminiChatbotService.getAverageSpendingByCategory();
+            String prompt = buildGeminiPrompt(spendingData, averageData);
             String geminiResponse = callGemini(prompt, geminiApiKey);
             String message = extractGeminiText(geminiResponse);
             Map<String, String> messages = splitGeminiMessages(message);
             return ResponseEntity.ok(messages);
         } catch (Exception e) {
             return ResponseEntity.ok(Map.of(
-                "spendingPattern", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요.",
-                "savingFeedback", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요.",
-                "spendingTips", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요."
+                "response1", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요.",
+                "response2", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요.",
+                "response3", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요.",
+                "response4", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요.",
+                "response5", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요.",
+                "response6", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요."
             ));
         }
     }
@@ -83,13 +90,19 @@ public class GeminiChatbotController {
         return true; // 요청 가능
     }
 
-    private static String buildGeminiPrompt(String spendingData) {
+    private static String buildGeminiPrompt(String spendingData, String averageData) {
         return "아래는 사용자의 최근 한 달 지출 내역입니다.\n" +
                 spendingData +
-                "\n1. 전체 소비 패턴을 한 문단으로 요약해줘.\n" +
-                "2. 절약 정도에 대한 피드백을 한 문단으로 줘.\n" +
-                "3. 지출이 많은 부분을 줄일 수 있는 구체적인 팁을 한 문단으로 알려줘.\n" +
-                "각 답변은 반드시 '1.', '2.', '3.'으로 시작하는 줄로 구분해서 출력해줘.";
+                "\n\n아래는 전체 사용자의 카테고리별 평균 지출입니다.\n" +
+                averageData +
+                "\n\n다음 6가지 질문에 대해 각각 한 문단씩 답변해주세요. 특히 3번 질문에서는 구체적인 금액 비교를 해주세요:\n" +
+                "1. 내가 제일 돈 많이 쓰는 건 어떤 분야 같니?\n" +
+                "2. 내 수입보다 많이 지출한 분야 뭐야?\n" +
+                "3. 다른 사람들보다 내가 많이 쓴 분야는 뭐야? (예: '전체 사용자 평균 식비 지출은 100,000원이고 사용자의 식비 지출액은 150,000원으로 평균보다 50,000원 더 많이 쓰셨어요')\n" +
+                "4. 절약 꿀팁이 뭐가 있어?\n" +
+                "5. 소비에서 절약할 수 있는 카테고리는 뭐야?\n" +
+                "6. 내가 어디서 돈을 아낄 수 있을 것 같니?\n" +
+                "각 답변은 반드시 '1.', '2.', '3.', '4.', '5.', '6.'으로 시작하는 줄로 구분해서 출력해줘.";
     }
 
     private static String callGemini(String prompt, String apiKey) throws IOException, InterruptedException {
@@ -120,17 +133,23 @@ public class GeminiChatbotController {
 
     private static Map<String, String> splitGeminiMessages(String geminiText) {
         Map<String, String> result = new java.util.HashMap<>();
-        String[] parts = geminiText.split("(?=\\n?\\d\\.)"); // "1.", "2.", "3." 앞에서 분리
+        String[] parts = geminiText.split("(?=\\n?\\d\\.)"); // "1.", "2.", "3.", "4.", "5.", "6." 앞에서 분리
         for (String part : parts) {
             String trimmed = part.trim();
-            if (trimmed.startsWith("1.")) result.put("spendingPattern", trimmed.substring(2).trim());
-            else if (trimmed.startsWith("2.")) result.put("savingFeedback", trimmed.substring(2).trim());
-            else if (trimmed.startsWith("3.")) result.put("spendingTips", trimmed.substring(2).trim());
+            if (trimmed.startsWith("1.")) result.put("response1", trimmed.substring(2).trim());
+            else if (trimmed.startsWith("2.")) result.put("response2", trimmed.substring(2).trim());
+            else if (trimmed.startsWith("3.")) result.put("response3", trimmed.substring(2).trim());
+            else if (trimmed.startsWith("4.")) result.put("response4", trimmed.substring(2).trim());
+            else if (trimmed.startsWith("5.")) result.put("response5", trimmed.substring(2).trim());
+            else if (trimmed.startsWith("6.")) result.put("response6", trimmed.substring(2).trim());
         }
         // 혹시 누락된 항목이 있으면 기본 메시지로 채움
-        if (!result.containsKey("spendingPattern")) result.put("spendingPattern", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요.");
-        if (!result.containsKey("savingFeedback")) result.put("savingFeedback", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요.");
-        if (!result.containsKey("spendingTips")) result.put("spendingTips", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요.");
+        if (!result.containsKey("response1")) result.put("response1", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요.");
+        if (!result.containsKey("response2")) result.put("response2", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요.");
+        if (!result.containsKey("response3")) result.put("response3", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요.");
+        if (!result.containsKey("response4")) result.put("response4", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요.");
+        if (!result.containsKey("response5")) result.put("response5", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요.");
+        if (!result.containsKey("response6")) result.put("response6", "Gemini 응답 생성에 실패했습니다. 다시 시도해주세요.");
         return result;
     }
 } 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/notification/NotificationController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/notification/NotificationController.java
@@ -59,11 +59,13 @@ public class NotificationController {
         public String message;
         public boolean read;
         public String type;
-        public TitleNotificationResponse(Long notificationId, String message, boolean read, String type) {
+        public Long aTId; // 획득한 칭호의 aTId 추가
+        public TitleNotificationResponse(Long notificationId, String message, boolean read, String type, Long aTId) {
             this.notificationId = notificationId;
             this.message = message;
             this.read = read;
             this.type = type;
+            this.aTId = aTId;
         }
     }
     public static class CreateNotificationRequest {

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/geminichatbot/repos/GeminiChatbotBudgetDetailRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/geminichatbot/repos/GeminiChatbotBudgetDetailRepository.java
@@ -20,4 +20,15 @@ public interface GeminiChatbotBudgetDetailRepository extends JpaRepository<Budge
         @Param("start") LocalDate start,
         @Param("end") LocalDate end
     );
+
+    @Query("""
+        SELECT d FROM BudgetDetail d
+        WHERE d.date BETWEEN :start AND :end
+          AND d.type = '지출'
+        ORDER BY d.date
+    """)
+    List<BudgetDetail> findAllExpenseDetailsByDateBetween(
+        @Param("start") LocalDate start,
+        @Param("end") LocalDate end
+    );
 } 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/geminichatbot/service/GeminiChatbotService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/geminichatbot/service/GeminiChatbotService.java
@@ -4,8 +4,11 @@ import com.grepp.spring.app.model.budget_detail.domain.BudgetDetail;
 import com.grepp.spring.app.model.geminichatbot.repos.GeminiChatbotBudgetDetailRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -16,13 +19,55 @@ public class GeminiChatbotService {
         LocalDate end = LocalDate.now();
         LocalDate start = end.minusMonths(1).plusDays(1);
         List<BudgetDetail> details = budgetDetailRepository.findExpenseDetailsByMemberIdAndDateBetween(memberId, start, end);
+        
+        // 카테고리별 총액 계산
+        Map<String, Double> categoryTotals = details.stream()
+            .collect(Collectors.groupingBy(
+                BudgetDetail::getCategory,
+                Collectors.summingDouble(detail -> detail.getPrice().doubleValue())
+            ));
+        
         StringBuilder sb = new StringBuilder();
+        sb.append("사용자 최근 한 달 지출 내역:\n");
         for (BudgetDetail d : details) {
             sb.append(d.getDate())
               .append(": ")
               .append(d.getCategory())
               .append(" ")
               .append(d.getPrice().intValue())
+              .append("원\n");
+        }
+        
+        sb.append("\n카테고리별 총 지출:\n");
+        for (Map.Entry<String, Double> entry : categoryTotals.entrySet()) {
+            sb.append(entry.getKey())
+              .append(": ")
+              .append(String.format("%.0f", entry.getValue()))
+              .append("원\n");
+        }
+        
+        return sb.toString();
+    }
+
+    // 전체 사용자의 카테고리별 평균 지출 계산
+    public String getAverageSpendingByCategory() {
+        LocalDate end = LocalDate.now();
+        LocalDate start = end.minusMonths(1).plusDays(1);
+        List<BudgetDetail> allDetails = budgetDetailRepository.findAllExpenseDetailsByDateBetween(start, end);
+        
+        // 카테고리별로 그룹화하여 평균 계산
+        Map<String, Double> categoryAverages = allDetails.stream()
+            .collect(Collectors.groupingBy(
+                BudgetDetail::getCategory,
+                Collectors.averagingDouble(detail -> detail.getPrice().doubleValue())
+            ));
+        
+        StringBuilder sb = new StringBuilder();
+        sb.append("전체 사용자 카테고리별 평균 지출 (최근 1개월):\n");
+        for (Map.Entry<String, Double> entry : categoryAverages.entrySet()) {
+            sb.append(entry.getKey())
+              .append(": ")
+              .append(String.format("%.0f", entry.getValue()))
               .append("원\n");
         }
         return sb.toString();

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/service/NotificationService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/service/NotificationService.java
@@ -121,7 +121,8 @@ public class NotificationService {
                         notification.getNotificationId(),
                         notification.getMessage(),
                         notification.getIsRead(),
-                        notification.getType()
+                        notification.getType(),
+                        notification.getSenderId() // senderId를 aTId로 활용
                 ))
                 .toList();
     }
@@ -156,6 +157,10 @@ public class NotificationService {
 
         public static NotificationCreateRequest of(Long receiverId, Long senderId, String type, String customMessage, String senderName) {
             return new NotificationCreateRequest(receiverId, senderId, type, customMessage, senderName, null);
+        }
+
+        public static NotificationCreateRequest of(Long receiverId, Long senderId, String type, String customMessage, String senderName, String title) {
+            return new NotificationCreateRequest(receiverId, senderId, type, customMessage, senderName, title);
         }
 
         // Getter 메서드들


### PR DESCRIPTION
## 개요
칭호 획득 알림 API 응답에 획득한 칭호의 aTId 를 추가

## 주요 변경사항
- `TitleNotificationResponse` DTO에 `aTId` 필드 추가
- `senderId` 필드를 활용하여 `aTId` 정보 전달
- TITLE 타입 알림에서 `senderId`에 `aTId` 저장

## 참고사항
- TITLE 타입 알림 생성 시 `senderId`에 `aTId` 전달
- 다른 타입(LIKE, COMMENT)은 기존대로 실제 발신자 ID 사용