### PR TITLE
fix: 알림 조회 시 읽지 않은 알림만 반환하도록 수정 및 전체 읽음 처리 API 추가

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/notification/NotificationController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/notification/NotificationController.java
@@ -135,4 +135,14 @@ public class NotificationController {
         notificationService.markNotificationAsRead(notificationId, principal.getMemberId());
         return ResponseEntity.ok(new ApiResponse<>("2000", "성공적으로 처리되었습니다.", null));
     }
+
+    // 특정 타입의 모든 알림 읽음 처리
+    @PatchMapping("/{type}/read-all")
+    @Operation(summary = "전체 알림 읽음 처리", description = "특정 타입의 모든 알림을 읽음 처리합니다.")
+    public ResponseEntity<ApiResponse<Void>> markAllNotificationsAsReadByType(
+            @PathVariable String type, 
+            @AuthenticationPrincipal Principal principal) {
+        notificationService.markAllNotificationsAsReadByType(principal.getMemberId(), type);
+        return ResponseEntity.ok(new ApiResponse<>("2000", "성공적으로 처리되었습니다.", null));
+    }
 } 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/repos/NotificationRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/repos/NotificationRepository.java
@@ -16,6 +16,19 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     // 멤버 ID, 타입, 활성화 상태로 알림 조회
     List<Notification> findByMemberMemberIdAndTypeAndActivatedTrue(Long memberId, String type);
 
+    // 읽지 않은 알림만 조회 (멤버 ID, 타입, 활성화 상태)
+    List<Notification> findByMemberMemberIdAndTypeAndIsReadFalseAndActivatedTrue(Long memberId, String type);
+
+    // 특정 타입의 모든 알림을 읽음 처리
+    @Query("UPDATE Notification n SET n.isRead = true, n.modifiedAt = :modifiedAt " +
+           "WHERE n.member.memberId = :memberId AND n.type = :type AND n.activated = true")
+    @org.springframework.data.jpa.repository.Modifying
+    @org.springframework.transaction.annotation.Transactional
+    int markAllNotificationsAsReadByType(
+        @Param("memberId") Long memberId,
+        @Param("type") String type,
+        @Param("modifiedAt") LocalDateTime modifiedAt);
+
     @Query("SELECT COUNT(n) > 0 FROM Notification n " +
         "WHERE n.member.memberId = :memberId " +
         "AND n.createdAt >= :start " +

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/service/NotificationService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/service/NotificationService.java
@@ -82,9 +82,9 @@ public class NotificationService {
         return notification;
     }
 
-    // 좋아요 알림 조회
+    // 좋아요 알림 조회 (읽지 않은 알림만)
     public List<LikeNotificationResponse> getLikeNotifications(Long memberId) {
-        List<Notification> notifications = notificationRepository.findByMemberMemberIdAndTypeAndActivatedTrue(memberId, "LIKE");
+        List<Notification> notifications = notificationRepository.findByMemberMemberIdAndTypeAndIsReadFalseAndActivatedTrue(memberId, "LIKE");
         
         return notifications.stream()
                 .map(notification -> new LikeNotificationResponse(
@@ -97,9 +97,9 @@ public class NotificationService {
                 .toList();
     }
 
-    // 댓글 알림 조회
+    // 댓글 알림 조회 (읽지 않은 알림만)
     public List<CommentNotificationResponse> getCommentNotifications(Long memberId) {
-        List<Notification> notifications = notificationRepository.findByMemberMemberIdAndTypeAndActivatedTrue(memberId, "COMMENT");
+        List<Notification> notifications = notificationRepository.findByMemberMemberIdAndTypeAndIsReadFalseAndActivatedTrue(memberId, "COMMENT");
         
         return notifications.stream()
                 .map(notification -> new CommentNotificationResponse(
@@ -112,9 +112,9 @@ public class NotificationService {
                 .toList();
     }
 
-    // 칭호 획득 알림 조회
+    // 칭호 획득 알림 조회 (읽지 않은 알림만)
     public List<TitleNotificationResponse> getTitleNotifications(Long memberId) {
-        List<Notification> notifications = notificationRepository.findByMemberMemberIdAndTypeAndActivatedTrue(memberId, "TITLE");
+        List<Notification> notifications = notificationRepository.findByMemberMemberIdAndTypeAndIsReadFalseAndActivatedTrue(memberId, "TITLE");
         
         return notifications.stream()
                 .map(notification -> new TitleNotificationResponse(
@@ -232,6 +232,16 @@ public class NotificationService {
         notification.setIsRead(true);
         notification.setModifiedAt(LocalDateTime.now());
         notificationRepository.save(notification);
+    }
+
+    // 특정 타입의 모든 알림 읽음 처리
+    public void markAllNotificationsAsReadByType(Long memberId, String type) {
+        int updatedCount = notificationRepository.markAllNotificationsAsReadByType(
+            memberId, type, LocalDateTime.now());
+        
+        if (updatedCount == 0) {
+            throw new NotFoundException("해당 타입의 읽지 않은 알림이 없습니다.");
+        }
     }
 
 }


### PR DESCRIPTION
## 개요
읽음 처리된 알림이 계속 표출되는 문제를 해결, 전체 알림 읽음 처리 기능 추가

## 주요 변경사항

### **버그 수정**
- **문제**: 읽음 처리된 알림이 계속 표출됨
- **해결**: 알림 조회 시 `isRead = false`인 알림만 반환하도록 수정
- **영향**: 좋아요, 댓글, 칭호 알림 조회 API

### **새로운 기능**
- **전체 알림 읽음 처리 API** 추가
- **엔드포인트**: `PATCH /api/notifications/{type}/read-all`
- **기능**: 특정 타입의 모든 읽지 않은 알림을 일괄 처리
- **지원 타입**: LIKE, COMMENT, TITLE

## 변경사항

### **Repository**
- `findByMemberMemberIdAndTypeAndIsReadFalseAndActivatedTrue()` 메서드 추가
- `markAllNotificationsAsReadByType()` 메서드 추가 (트랜잭션 지원)

### **Service**
- 알림 조회 메서드들이 읽지 않은 알림만 반환하도록 수정
- `markAllNotificationsAsReadByType()` 메서드 추가

### **Controller**
- `PATCH /{type}/read-all` 엔드포인트 추가