### PR TITLE
refactor: 불필요한 토큰 재발급 API 제거

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/MemberController.java
@@ -1230,57 +1230,5 @@ public class MemberController {
         }
     }
 
-    @PostMapping("/token/refresh")
-    @Operation(summary = "엑세스 토큰 재발급", description = "쿠키의 리프레시 토큰을 이용해 새로운 엑세스 토큰과 리프레시 토큰을 발급합니다.")
-    public ResponseEntity<ApiResponse<TokenRefreshResponse>> refreshToken(HttpServletRequest request, HttpServletResponse response) {
-        // 1. 쿠키에서 refreshToken 추출
-        String refreshToken = jwtTokenProvider.resolveToken(request, AuthToken.REFRESH_TOKEN);
-        if (refreshToken == null || refreshToken.isBlank()) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(new ApiResponse<>(ResponseCode.BAD_REQUEST.code(), "리프레시 토큰이 필요합니다.", null));
-        }
-        // 2. refreshToken에서 accessToken jti 추출
-        String atId;
-        try {
-            atId = jwtTokenProvider.getJtiFromToken(refreshToken);
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(new ApiResponse<>(ResponseCode.UNAUTHORIZED.code(), "유효하지 않은 리프레시 토큰입니다.", null));
-        }
-        // 3. Redis에서 refreshToken 정보 조회 및 검증
-        var stored = refreshTokenService.findByAccessTokenId(atId);
-        if (stored == null || !stored.getToken().equals(refreshToken)) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(new ApiResponse<>(ResponseCode.UNAUTHORIZED.code(), "리프레시 토큰이 일치하지 않습니다.", null));
-        }
-        // 4. 새 accessToken/refreshToken 발급
-        String email = jwtTokenProvider.getUsername(refreshToken);
-        String roles = jwtTokenProvider.getRoles(refreshToken);
-        var accessTokenDto = jwtTokenProvider.generateAccessToken(email, roles);
-        var newRefreshToken = refreshTokenService.renewingToken(atId, accessTokenDto.getJti());
-        // 5. 쿠키로도 내려줌(선택)
-        ResponseCookie accessTokenCookie = TokenCookieFactory.create("accessToken", accessTokenDto.getToken(), accessTokenDto.getExpires());
-        ResponseCookie refreshTokenCookie = TokenCookieFactory.create("refreshToken", newRefreshToken.getToken(), newRefreshToken.getTtl());
-        response.addHeader("Set-Cookie", accessTokenCookie.toString());
-        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
-        // 6. 응답
-        TokenRefreshResponse resp = new TokenRefreshResponse(accessTokenDto.getToken(), newRefreshToken.getToken(), "Bearer", accessTokenDto.getExpires(), newRefreshToken.getTtl());
-        return ResponseEntity.ok(ApiResponse.success(resp));
-    }
 
-
-
-    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
-    public static class TokenRefreshResponse {
-        @Schema(description = "새 엑세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
-        private String accessToken;
-        @Schema(description = "새 리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
-        private String refreshToken;
-        @Schema(description = "토큰 타입", example = "Bearer")
-        private String grantType;
-        @Schema(description = "엑세스 토큰 만료(ms)", example = "3600000")
-        private Long expiresIn;
-        @Schema(description = "리프레시 토큰 만료(ms)", example = "604800000")
-        private Long refreshExpiresIn;
-    }
 } 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/mock/member/MemberMockController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/mock/member/MemberMockController.java
@@ -140,22 +140,7 @@ public class MemberMockController {
     }
 
 
-    @PostMapping("/token/refresh")
-    public ResponseEntity<ApiResponse<MemberLoginResponse>> refreshToken(@RequestBody MemberTokenRefreshRequest request) {
-        // JWT 토큰 갱신 Mock 응답
-        String newAccessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwicm9sZXMiOiJST0xFX1VTRVIiLCJqdGkiOiJuZXctYWNjZXNzLXRva2VuLWlkIiwiaWF0IjoxNzMxOTIwMDAwLCJleHAiOjE3MzE5MjM2MDB9.new-mock-signature";
-        String newRefreshToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwianRpIjoibmV3LXJlZnJlc2gtdG9rZW4taWQiLCJpYXQiOjE3MzE5MjAwMDAsImV4cCI6MTczMTkyODgwMH0.new-mock-refresh-signature";
-        
-        MemberLoginResponse.Data data = new MemberLoginResponse.Data(
-                newAccessToken,
-                newRefreshToken,
-                "Bearer",
-                3600L,
-                28800L
-        );
-        MemberLoginResponse response = new MemberLoginResponse(2000, "토큰이 갱신되었습니다.", data);
-        return ResponseEntity.ok(ApiResponse.success(response));
-    }
+
 
     @GetMapping("/mypage")
     public ResponseEntity<ApiResponse<MemberMypageResponse>> getMypage() {
@@ -397,13 +382,7 @@ public class MemberMockController {
         }
     }
 
-    @Getter
-    @Setter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class MemberTokenRefreshRequest {
-        private String refreshToken;
-    }
+
 
     @Getter
     @Setter


### PR DESCRIPTION
## 불필요한 토큰 재발급 API 제거

- JwtAuthenticationFilter에서 자동 토큰 갱신 처리로 인해 수동 API 불필요
- MemberController에서 /api/members/token/refresh 엔드포인트 제거
- TokenRefreshResponse, MemberTokenRefreshRequest DTO 클래스 제거