### PR TITLE
refactor: 컨트롤러 예외 처리 통일 및 ResponseCode 추가

### DIFF
--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/EmailVerificationController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/EmailVerificationController.java
@@ -8,6 +8,7 @@ import com.grepp.spring.app.model.member.dto.EmailVerificationVerifyResponse;
 import com.grepp.spring.app.model.member.dto.EmailVerificationStatusResponse;
 import com.grepp.spring.infra.response.ApiResponse;
 import com.grepp.spring.infra.response.ResponseCode;
+import com.grepp.spring.infra.error.exceptions.CommonException;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -45,8 +46,7 @@ public class EmailVerificationController {
         if (isValid) {
             return ResponseEntity.ok(ApiResponse.success(new EmailVerificationVerifyResponse("이메일 인증이 완료되었습니다.")));
         } else {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(new ApiResponse<>(ResponseCode.BAD_REQUEST.code(), "인증 코드가 올바르지 않거나 만료되었습니다.", null));
+            throw new CommonException(ResponseCode.INVALID_EMAIL_CODE);
         }
     }
     

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/OAuth2SignupController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/member/OAuth2SignupController.java
@@ -13,6 +13,7 @@ import com.grepp.spring.infra.auth.jwt.TokenCookieFactory;
 import com.grepp.spring.infra.config.security.UserDetailsServiceImpl;
 import com.grepp.spring.infra.response.ApiResponse;
 import com.grepp.spring.infra.response.ResponseCode;
+import com.grepp.spring.infra.error.exceptions.CommonException;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -47,14 +48,12 @@ public class OAuth2SignupController {
         
         // 이메일 중복 체크
         if (memberRepository.existsByEmailIgnoreCase(request.getEmail())) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(new ApiResponse<>(ResponseCode.BAD_REQUEST.code(), "이미 가입된 이메일입니다.", null));
+            throw new CommonException(ResponseCode.EMAIL_ALREADY_EXISTS);
         }
         
         // 닉네임 중복 체크
         if (memberRepository.findAll().stream().anyMatch(m -> m.getNickname().equalsIgnoreCase(request.getNickname()))) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(new ApiResponse<>(ResponseCode.BAD_REQUEST.code(), "이미 사용중인 닉네임입니다.", null));
+            throw new CommonException(ResponseCode.NICKNAME_ALREADY_EXISTS);
         }
         
         // 회원 생성

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/notification/NotificationController.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/controller/api/notification/NotificationController.java
@@ -81,13 +81,12 @@ public class NotificationController {
         return ResponseEntity.ok(new ApiResponse<>("2000", "성공적으로 처리되었습니다.", null));
     }
 
-    // 특정 타입의 모든 알림 읽음 처리
-    @PatchMapping("/{type}/read-all")
-    @Operation(summary = "전체 알림 읽음 처리", description = "특정 타입의 모든 알림을 읽음 처리합니다.")
-    public ResponseEntity<ApiResponse<Void>> markAllNotificationsAsReadByType(
-            @PathVariable String type, 
+    // 모든 알림 읽음 처리
+    @PatchMapping("/read-all")
+    @Operation(summary = "전체 알림 읽음 처리", description = "모든 알림을 읽음 처리합니다.")
+    public ResponseEntity<ApiResponse<Void>> markAllNotificationsAsRead(
             @AuthenticationPrincipal Principal principal) {
-        notificationService.markAllNotificationsAsReadByType(principal.getMemberId(), type);
+        notificationService.markAllNotificationsAsRead(principal.getMemberId());
         return ResponseEntity.ok(new ApiResponse<>("2000", "성공적으로 처리되었습니다.", null));
     }
 } 

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/repos/NotificationRepository.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/repos/NotificationRepository.java
@@ -21,12 +21,21 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     // 특정 타입의 모든 알림을 읽음 처리
     @Query("UPDATE Notification n SET n.isRead = true, n.modifiedAt = :modifiedAt " +
-           "WHERE n.member.memberId = :memberId AND n.type = :type AND n.activated = true")
+           "WHERE n.member.memberId = :memberId AND n.type = :type AND n.isRead = false AND n.activated = true")
     @org.springframework.data.jpa.repository.Modifying
     @org.springframework.transaction.annotation.Transactional
     int markAllNotificationsAsReadByType(
         @Param("memberId") Long memberId,
         @Param("type") String type,
+        @Param("modifiedAt") LocalDateTime modifiedAt);
+    
+    // 모든 알림을 읽음 처리
+    @Query("UPDATE Notification n SET n.isRead = true, n.modifiedAt = :modifiedAt " +
+           "WHERE n.member.memberId = :memberId AND n.isRead = false AND n.activated = true")
+    @org.springframework.data.jpa.repository.Modifying
+    @org.springframework.transaction.annotation.Transactional
+    int markAllNotificationsAsRead(
+        @Param("memberId") Long memberId,
         @Param("modifiedAt") LocalDateTime modifiedAt);
 
     @Query("SELECT COUNT(n) > 0 FROM Notification n " +

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/service/NotificationService.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/app/model/notification/service/NotificationService.java
@@ -240,5 +240,12 @@ public class NotificationService {
             memberId, type, LocalDateTime.now());
         // 읽지 않은 알림이 없어도 성공으로 처리 (에러를 던지지 않음)
     }
+    
+    // 모든 알림 읽음 처리
+    public void markAllNotificationsAsRead(Long memberId) {
+        notificationRepository.markAllNotificationsAsRead(
+            memberId, LocalDateTime.now());
+        // 읽지 않은 알림이 없어도 성공으로 처리 (에러를 던지지 않음)
+    }
 
 }

--- a/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/response/ResponseCode.java
+++ b/apimocking-main/apimocking-boilerplate/src/main/java/com/grepp/spring/infra/response/ResponseCode.java
@@ -17,7 +17,16 @@ public enum ResponseCode {
     NOT_FOUND_DETAIL("DETAIL_001", HttpStatus.NOT_FOUND,"해당 지출내역을 찾을 수 없습니다"),
     NOT_FOUND_CHALLENGE("CHALLENGE_001",HttpStatus.NOT_FOUND,"해당 챌린지를 찾을 수 없습니다"),
     ALREADY_REGISTERED_NO_EXPENSE("NO_EXPENSE_001", HttpStatus.CONFLICT,"오늘은 이미 지출 없음 등록이 되어있습니다."),
-    ALREADY_REGISTERED_EXPENSE("EXPENSE_001", HttpStatus.CONFLICT, "오늘은 지출이 등록되어있습니다. 확인해주세요.");
+    ALREADY_REGISTERED_EXPENSE("EXPENSE_001", HttpStatus.CONFLICT, "오늘은 지출이 등록되어있습니다. 확인해주세요."),
+    // 회원 관련 에러 코드
+    EMAIL_ALREADY_EXISTS("MEMBER_002", HttpStatus.BAD_REQUEST, "이미 사용중인 이메일입니다."),
+    NICKNAME_ALREADY_EXISTS("MEMBER_003", HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다."),
+    PASSWORD_MISMATCH("MEMBER_004", HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    EMAIL_NOT_VERIFIED("MEMBER_005", HttpStatus.BAD_REQUEST, "이메일 인증이 필요합니다."),
+    INVALID_INVITE_CODE("MEMBER_006", HttpStatus.BAD_REQUEST, "유효하지 않은 초대코드입니다."),
+    INVALID_PASSWORD_FORMAT("MEMBER_007", HttpStatus.BAD_REQUEST, "비밀번호는 8자 이상, 영문/숫자/특수문자를 모두 포함해야 합니다."),
+    INVALID_TITLE_ID("MEMBER_008", HttpStatus.BAD_REQUEST, "유효하지 않은 칭호 ID입니다."),
+    INVALID_EMAIL_CODE("MEMBER_009", HttpStatus.BAD_REQUEST, "인증 코드가 올바르지 않거나 만료되었습니다.");
     
     private final String code;
     private final HttpStatus status;


### PR DESCRIPTION
- Member, EmailVerification, OAuth2Signup 컨트롤러의 예외 처리 통일
- ResponseEntity 직접 반환 → CommonException 던지기로 변경
- 회원 관련 구체적인 ResponseCode 추가
- @ExceptionHandler를 통한 중앙화된 예외 처리로 일관성 확보